### PR TITLE
Feat: Alerts To Recipient List When Certain Users Are Active

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -1,4 +1,17 @@
 {
+  "handlers": {
+    "alerts": {
+      "alertworthy_users": [
+        624288379202174996,
+        757682704274948106
+      ],
+      "alert_recipients": [
+        572540272563716116,
+        473331439169962005,
+        735658100958298154
+      ]
+    }
+  },
   "tasks": {
     "weyounsday": {
       "channels": [
@@ -576,6 +589,7 @@
     "louvois_point_yes": "<:louvois_point_yes:840252104056766515>",
     "picard_yes_happy_celebrate": "<:picard_yes_happy_celebrate:757726753346027622>",
     "ohno": "<:ohno:930365904657723402>",
+    "red_alert": "<a:red_alert:852987099257765938>",
     "tendi_smile_happy": "<:tendi_smile_happy:757768236069814283>",
     "tgg_love_heart": "<:love_heart_tgg:798600300264161280>",
     "weyoun_love_heart": "<:weyoun_love_heart:864953513637445653>",
@@ -617,7 +631,7 @@
     "Historical Note: The humans cast the first stone.",
     "I'm getting my buddy SkyNet on the phone..."
   ],
-  "leave_messages":[
+  "leave_messages": [
     "**{}** went to a conference...",
     "**{}** got sucked into the mirror universe",
     "**{}** was kidnapped by Cardassians",

--- a/handlers/alerts.py
+++ b/handlers/alerts.py
@@ -1,0 +1,31 @@
+from commands.common import *
+
+from datetime import datetime, timedelta
+
+alert_log = {}
+alert_config = config["handlers"]["alerts"]
+
+async def handle_alerts(message:discord.Message):
+  alertworthy_users = alert_config["alertworthy_users"]
+  alert_recipients = alert_config["alert_recipients"]
+
+  author_id = message.author.id
+  if author_id in alertworthy_users:
+    recency_check_date = alert_log.get(author_id)
+    if recency_check_date:
+      check = datetime.now() - recency_check_date
+      if check < timedelta(hours=2):
+        # If we've already done an alert within 2 hours for this user, no need for another
+        return
+
+    # If we haven't already early returned from the check,
+    # stamp the current time for this user in our in-memory alert_log
+    alert_log[author_id] = datetime.now()
+
+    # Alert recipients
+    alertworthy_user = await client.fetch_user(author_id)
+    logger.info(f"{Fore.LIGHTCYAN_EX}{Style.BRIGHT}{alertworthy_user.display_name}{Style.RESET_ALL} is active on the Discord! {Fore.LIGHTCYAN_EX}{Style.BRIGHT}Sending alerts!{Style.RESET_ALL}{Fore.RESET}")
+    for recipient_id in alert_recipients:
+      recipient_user = await client.fetch_user(recipient_id)
+      await recipient_user.send(f"Hey {recipient_user.display_name}, looks like **{alertworthy_user.display_name}** is active on the Discord!\n{message.jump_url}")
+    

--- a/handlers/bot_autoresponse.py
+++ b/handlers/bot_autoresponse.py
@@ -1,4 +1,4 @@
-from .common import *
+from commands.common import *
 
 # Load up our list of complimentary and condemnation adjectives
 with open('bot_affirmations.txt') as f:

--- a/handlers/unit_conversion.py
+++ b/handlers/unit_conversion.py
@@ -1,4 +1,4 @@
-from .common import *
+from commands.common import *
 
 from quantulum3 import parser
 from pint import UnitRegistry

--- a/handlers/xp.py
+++ b/handlers/xp.py
@@ -1,4 +1,4 @@
-from .common import *
+from commands.common import *
 
 xp_colors = [
     Fore.RED,

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import traceback
 
+# Commands
 from commands.common import *
-from commands.bot_autoresponse import handle_bot_affirmations
 from commands.buy import buy
 from commands.categories import categories
 from commands.clear_media import clear_media
@@ -29,13 +29,18 @@ from commands.triv import *
 from commands.trekduel import trekduel
 from commands.trektalk import trektalk
 from commands.tuvix import tuvix
-from commands.unit_conversion import handle_mentioned_units
 from commands.update_status import update_status
-from commands.xp import handle_message_xp, handle_react_xp
 from commands.server_logs import show_leave_message, show_nick_change_message
+# Handlers
+from handlers.alerts import handle_alerts
+from handlers.bot_autoresponse import handle_bot_affirmations
+from handlers.unit_conversion import handle_mentioned_units
+from handlers.xp import handle_message_xp, handle_react_xp
+# Tasks
 from tasks.scheduler import Scheduler
 from tasks.bingbong import bingbong_task
 from tasks.weyounsday import weyounsday_task
+# Utils
 from utils.check_channel_access import perform_channel_check
 
 logger.info(f"{Style.BRIGHT}{Fore.LIGHTMAGENTA_EX}ENVIRONMENT VARIABLES AND COMMANDS LOADED{Fore.RESET}")
@@ -53,8 +58,14 @@ async def on_message(message:discord.Message):
   if message.author == client.user:
     return
 
-  await handle_bot_affirmations(message)  
-  await handle_mentioned_units(message)
+  # Special message Handlers
+  try:
+    await handle_bot_affirmations(message)
+    await handle_mentioned_units(message)
+    await handle_alerts(message)
+  except Exception as e:
+    logger.error(f"{Fore.RED}<! ERROR: Encountered error in handlers !> {e}{Fore.RESET}")
+    logger.error(traceback.format_exc())
 
   if int(message.author.id) not in ALL_USERS:
     logger.info(f"{Fore.LIGHTMAGENTA_EX}{Style.BRIGHT}New User{Style.RESET_ALL}{Fore.RESET}")
@@ -79,6 +90,7 @@ async def on_message(message:discord.Message):
           await message.add_reaction(i)
   except Exception as e:
     logger.error(f"{Fore.RED}<! ERROR: Failed to process message for xp !> {e}{Fore.RESET}")
+    logger.error(traceback.format_exc())
   
   # Bang Command Handling
   #logger.debug(message)


### PR DESCRIPTION
Uxbridge-Shimoda batphone. Sends a DM to users on the list (jp00p, draxiom, and myself currently) when Ben/Adam are active on the Discord. Has an in-memory timeout of 2 hours so only the first message within that time will send the alert.

Also moved the handlers into their own directory rather than mixed in with commands.