### PR TITLE
Improvement: Include message.content in Discord Exception Embed

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,7 +87,7 @@ async def on_message(message:discord.Message):
       logger.info(f">>> Encountered Exception!")
       logger.info(e)
       exception_embed = discord.Embed(
-        title="Oops...",
+        title=f"Oops... Encountered exception processing request: {message.content}",
         description=f"{e}\n```{traceback.format_exc()}```",
         color=discord.Color.red()
       )


### PR DESCRIPTION
Added this so that when the bot posts command exceptions info via Discord we also include `message.content` so we can get a better idea which command is failing.