### PR TITLE
Refactor: Move `drop` and `clip` Slash Commands To Command Groups

### DIFF
--- a/commands/clip.py
+++ b/commands/clip.py
@@ -3,7 +3,7 @@ from utils.check_channel_access import access_check
 from utils.media_utils import *
 from utils.timekeeper import *
 
-command_config = config["commands"]["clip"]
+command_config = config["commands"]["clip post"]
 emojis = config["emojis"]
 
 # Load JSON Data
@@ -11,13 +11,16 @@ f = open(command_config["data"])
 clip_data = json.load(f)
 f.close()
 
-# clips() - Entrypoint for /clip command
+# Create drop Slash Command Group
+clip = bot.create_group("clip", "Clip Commands!")
+
+# clip_list() - Entrypoint for `/clip list`` command
 # List the available clips by key and send to user as ephemeral
-@bot.slash_command(
-  name="clips",
+@clip.command(
+  name="list",
   description="Retrieve the List of Clips.",
 )
-async def clips(ctx:discord.ApplicationContext):
+async def clips_list(ctx:discord.ApplicationContext):
   clips_list = "\n".join(clip_data)
   embed = discord.Embed(
     title="List of Clips",
@@ -31,12 +34,12 @@ async def clips(ctx:discord.ApplicationContext):
     await ctx.respond(embed=embed, ephemeral=True)
 
 
-# clip() - Entrypoint for /clip command
+# clip_post() - Entrypoint for `/clip post` command
 # Parses a query, determines if it's allowed in the channel,
 # and if allowed retrieve from metadata to do matching and
 # then send the .mp4 file
-@bot.slash_command(
-  name="clip",
+@clip.command(
+  name="post",
   description="Send a clip to the channel!",
 )
 @option(
@@ -50,7 +53,7 @@ async def clips(ctx:discord.ApplicationContext):
   required=False
 )
 @commands.check(access_check)
-async def clip(ctx:discord.ApplicationContext, query:str, private:bool):
+async def clip_post(ctx:discord.ApplicationContext, query:str, private:bool):
   logger.info(f"{Fore.RED}Firing /clip command!{Fore.RESET}")
   # Private drops are not on the timer
   clip_allowed = True

--- a/commands/drop.py
+++ b/commands/drop.py
@@ -3,7 +3,7 @@ from utils.check_channel_access import access_check
 from utils.media_utils import *
 from utils.timekeeper import *
 
-command_config = config["commands"]["drop"]
+command_config = config["commands"]["drop post"]
 emojis = config["emojis"]
 
 # Load JSON Data
@@ -11,13 +11,16 @@ f = open(command_config["data"])
 drop_data = json.load(f)
 f.close()
 
-# slash_drops() - Entrypoint for /drops command
+# Create drop Slash Command Group
+drop = bot.create_group("drop", "Drop Commands!")
+
+# drop_list() - Entrypoint for `/drops list`` command
 # List the available drops by key and send to user as ephemeral
-@bot.slash_command(
-  name="drops",
+@drop.command(
+  name="list",
   description="Retrieve the List of Drops."
 )
-async def drops(ctx:discord.ApplicationContext):
+async def drop_list(ctx:discord.ApplicationContext):
   drops_list = "\n".join(drop_data)
   embed = discord.Embed(
     title="List of Drops",
@@ -30,13 +33,13 @@ async def drops(ctx:discord.ApplicationContext):
   except BaseException as e:
     await ctx.respond(embed=embed, ephemeral=True)
 
-# drop() - Entrypoint for /drops command
+# drop_post() - Entrypoint for `/drops post` command
 # Parses a query, determines if it's allowed in the channel,
 # and if allowed retrieve from metadata to do matching and
 # then send the .mp4 file
-@bot.slash_command(
-  name="drop",
-  description="Send a drop to the channel!",
+@drop.command(
+  name="post",
+  description="Send a drop to the channel or to just yourself via the <private> option!",
 )
 @option(
   name="query",
@@ -49,7 +52,7 @@ async def drops(ctx:discord.ApplicationContext):
   required=False,
 )
 @commands.check(access_check)
-async def drop(ctx:discord.ApplicationContext, query:str, private:bool):
+async def drop_post(ctx:discord.ApplicationContext, query:str, private:bool):
   logger.info(f"{Fore.RED}Firing drop command!{Fore.RESET}")
   # Private drops are not on the timer
   drop_allowed = True

--- a/configuration.json
+++ b/configuration.json
@@ -12,7 +12,7 @@
       ]
     },
     "starboard": {
-      "blocked_channels" : [
+      "blocked_channels": [
         "neelixs-morale-office",
         "plasma-vent",
         "counselor-trois-office",
@@ -37,11 +37,18 @@
         "polls"
       ],
       "boards": {
-        
-          "the-argus-array" : [],
-          "bits-bits-bits" : ["laugh", "lol", "lmao", "bits"],
-          "faith-of-the-heart" : ["love", "heart", "hearts"] 
-        
+        "the-argus-array": [],
+        "bits-bits-bits": [
+          "laugh",
+          "lol",
+          "lmao",
+          "bits"
+        ],
+        "faith-of-the-heart": [
+          "love",
+          "heart",
+          "hearts"
+        ]
       }
     }
   },
@@ -80,14 +87,14 @@
         }
       ]
     },
-    "reports":{
-      "channels":[
+    "reports": {
+      "channels": [
         "robot-diagnostics",
         "mclaughlin-group",
         "mo-pips-mo-problems"
       ],
-      "enabled":true,
-      "parameters":[]
+      "enabled": true,
+      "parameters": []
     },
     "categories": {
       "channels": [
@@ -105,7 +112,7 @@
       "data": null,
       "parameters": []
     },
-    "clip": {
+    "clip post": {
       "channels": [],
       "blocked_channels": [
         "neelixs-morale-office",
@@ -137,7 +144,7 @@
       "data": "data/all_characters.txt",
       "parameters": []
     },
-    "drop": {
+    "drop post": {
       "channels": [],
       "blocked_channels": [
         "neelixs-morale-office",

--- a/main.py
+++ b/main.py
@@ -195,12 +195,26 @@ async def on_member_update(memberBefore,memberAfter):
   if memberBefore.nick != memberAfter.nick:
     await show_nick_change_message(memberBefore, memberAfter) 
 
-# listen to slash command exceptions
+# Listen to channel updates
 @bot.event
-async def on_application_command_error(ctx, e):
-  # We don't want to log access_check denials
-  if e.__class__.__name__ == "CheckFailure":
-    return
+async def on_guild_channel_create(channel):
+  await show_channel_creation_message(channel)
+
+@bot.event
+async def on_guild_channel_delete(channel):
+  await show_channel_deletion_message(channel)
+
+@bot.event
+async def on_guild_channel_update(before, after):
+ await show_channel_rename_message(before, after)
+ await show_channel_topic_change_message(before, after)
+
+# listen to interaction errors
+@bot.event
+async def on_application_command_error(ctx, exception):
+  logger.error(f"{Fore.RED}Error encountered in slash command: /{ctx.command}")
+  logger.info(exception)
+
 
   # Otherwise log problems we might have
   logger.error(f"{Fore.RED}Error encountered in slash command: /{ctx.command}")

--- a/main.py
+++ b/main.py
@@ -6,9 +6,7 @@
 from common import *
 
 # Slash Commands
-from commands.drop import drop, drops
 from commands.dustbuster import dustbuster
-from commands.clip import clip, clips
 from commands.fmk import fmk
 from commands.help import help
 from commands.info import info
@@ -20,6 +18,10 @@ from commands.randomep import randomep
 from commands.trekduel import trekduel
 from commands.trektalk import trektalk
 from commands.tuvix import tuvix
+
+# Slash Command Groups
+import commands.drop
+import commands.clip
 
 # Bang Commands
 from commands.buy import buy
@@ -193,11 +195,16 @@ async def on_member_update(memberBefore,memberAfter):
   if memberBefore.nick != memberAfter.nick:
     await show_nick_change_message(memberBefore, memberAfter) 
 
-# listen to interaction errors
+# listen to slash command exceptions
 @bot.event
-async def on_application_command_error(ctx, exception):
+async def on_application_command_error(ctx, e):
+  # We don't want to log access_check denials
+  if e.__class__.__name__ == "CheckFailure":
+    return
+
+  # Otherwise log problems we might have
   logger.error(f"{Fore.RED}Error encountered in slash command: /{ctx.command}")
-  logger.info(exception)
+  logger.info(e)
 
 
 # Schedule Tasks


### PR DESCRIPTION
This lets us bundle all of the `/drop` and `/clip` commands under a group so that we can eliminate having separate `/` entry points for the related commands (like `/drops` and `/drop`). Instead the user will be prompted with the sub-commands `list` or `post` which function exactly like they did before.

![image](https://user-images.githubusercontent.com/1075211/177433830-318ec111-362b-4aab-bc2e-056f2466838b.png)
