### PR TITLE
Automatically bump/patch helm chart if the metadata is updated in ghaction

### DIFF
--- a/.github/workflows/update-tgg.yaml
+++ b/.github/workflows/update-tgg.yaml
@@ -23,6 +23,12 @@ jobs:
         with:
           token: ${{ secrets.GIT_TOKEN }}
           fetch-depth: 0
+      - 
+        name: Install semver with asdf
+        uses: asdf-vm/actions/install@v1
+        with:
+          tool_versions: |
+            semver 3.3.0
 
       -
         name: Update The Greatest Generation Metadata
@@ -36,6 +42,13 @@ jobs:
           git config user.email github-actions@github.com
           git diff
           git add data/episodes/*.json
-          git commit -m "Update The Greatest Generation Metadata - $(date)"
-          git push origin main
+          if [[ $(git status --porcelain) ]]; then
+            # metadata was updated, bump/patch the semver in the helm chart and push to main
+            sed -i 's/'$(make version)'/v'$(semver bump patch $(make version))'/g' charts/agimus/Chart.yaml
+            git add charts/agimus/Chart.yaml
+            git commit -m "Update The Greatest Generation Metadata - $(date)"
+            git push origin main
+          else
+            echo "There were no updates found for this show's metadata."
+          fi
 

--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v0.1.4
-appVersion: v0.1.4
+version: v0.1.5
+appVersion: v0.1.5


### PR DESCRIPTION
This change should install the [semver tool](https://github.com/fsaintjacques/semver-tool) via asdf and if there is an update to the meatadata in the update-tgg.yaml action, it will also bump/patch the semantic version in the helm chart before pushing to the main branch. This will prevent the update-tgg metadata action from overwriting existing container/packages already saved in ghcr.