### PR TITLE
Tweak: Supply AGIMUS Info in OpenAI Prompt

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v0.2.9
-appVersion: v0.2.9
+version: v0.2.10
+appVersion: v0.2.10

--- a/commands/computer.py
+++ b/commands/computer.py
@@ -165,9 +165,12 @@ async def handle_non_primary_result(res, message:discord.Message):
     return False
 
 async def handle_openai_response(question, message):
+
+  prompt_start = "You are a mischievous computer intelligence named AGIMUS. Answer the following prompt"
+
   completion = openai.Completion.create(
     engine=command_config["openai_model"],
-    prompt=f"Computer: {question}",
+    prompt=f"{prompt_start}: {question}",
     temperature=0.75,
     max_tokens=196,
     stop=["  "]


### PR DESCRIPTION
We can give the OpenAI prompt a little more context with the following supplied before each query:

"You are a mischevious computer intelligence named AGIMUS. Answer the following prompt:"