### PR TITLE
Fix: Set Logging Level Of 'openai' To WARNING Rather Than Defaulting To INFO

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v0.2.13
-appVersion: v0.2.13
+version: v0.2.14
+appVersion: v0.2.14

--- a/commands/computer.py
+++ b/commands/computer.py
@@ -3,6 +3,9 @@ import openai
 
 from common import *
 
+openai_logger = logging.getLogger('openai')
+openai_logger.setLevel('WARNING')
+
 WOLFRAM_ALPHA_ID = os.getenv('WOLFRAM_ALPHA_ID')
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 


### PR DESCRIPTION
Makes the logs less noisy and still logs critical info should something go awry.