### PR TITLE
Trivia/Shop Fix: Fetch `original_message` And Check Existence Before Attempting To Edit

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v0.2.26
-appVersion: v0.2.26
+version: v0.2.27
+appVersion: v0.2.27

--- a/cogs/shop.py
+++ b/cogs/shop.py
@@ -201,7 +201,7 @@ class Shop(commands.Cog):
 
 
   async def edit_interaction_with_thanks(self, page_interaction):
-    thank_you_embed=discord.Embed(
+    thank_you_embed = discord.Embed(
       title="Thank you for visiting The Shop!",
       color=discord.Color(0xFFFFFF)
     )
@@ -209,10 +209,12 @@ class Shop(commands.Cog):
     try:
       page_interaction_type = type(page_interaction).__name__
       if page_interaction_type == 'Interaction':
-        await page_interaction.edit_original_message(
-          embed=thank_you_embed,
-          view=None
-        )
+        original_message = await page_interaction.original_message()
+        if original_message != None:
+          await original_message.edit(
+            embed=thank_you_embed,
+            view=None
+          )
       elif page_interaction_type == 'InteractionMessage':
         await page_interaction.edit(
           embed=thank_you_embed,

--- a/cogs/trivia.py
+++ b/cogs/trivia.py
@@ -53,14 +53,12 @@ class Trivia(commands.Cog):
     self.trivia_answers = {}
     self.trivia_message = None
     self.trivia_running = False
-    self.original_response = None
   
   def clear_data(self):
     self.trivia_data = {}
     self.trivia_answers = {}
     self.trivia_message = None
     self.trivia_running = False
-    self.original_response = None
 
   async def answer_button_callback(self, interaction, answer_index):
     trivia_answer = {
@@ -124,7 +122,7 @@ class Trivia(commands.Cog):
 
       embed.set_footer(text="Select a button below with your answer!")
       # channel = bot.get_channel(config["channels"]["quizzing-booth"])
-      self.original_response = self.trivia_message = await ctx.respond(
+      self.trivia_message = await ctx.respond(
         embed=embed,
         file=thumb,
         view=view
@@ -195,7 +193,9 @@ class Trivia(commands.Cog):
         increase_jackpot(reward)
 
       # Disable all the answer buttons now that the trivia session is over
-      await self.original_response.edit_original_message(view=None)
+      original_message = await self.trivia_message.original_message()
+      if original_message != None:
+        await original_message.edit(view=None)
 
       self.clear_data()
 


### PR DESCRIPTION
Sometimes the message we're trying to edit for these commands will be invalid and we were attempting to edit it which means the command would crash. We now fetch the `original_message` and check if it's not None before we attempt to do so. 👍 