### PR TITLE
Fix: Prevent Users From Receiving Badges They Acquired During Trade Pending

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.2.3
-appVersion: v1.2.3
+version: v1.2.4
+appVersion: v1.2.4

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -259,10 +259,8 @@ class Trade(commands.Cog):
     # IF they do, then cancel the trade
     requestor_badges = db_get_user_badge_names(active_trade["requestor_id"])
     existing_requestor_badges = [b["badge_name"].replace('_', ' ').replace('.png', '') for b in requestor_badges]
-    logger.info(f"existing_requestor_badges - {existing_requestor_badges}")
     trade_requestor_badges = db_get_trade_requested_badges(active_trade)
     trade_requestor_badge_names = [b["badge_name"] for b in trade_requestor_badges]
-    logger.info(f"trade_requestor_badge_names - {trade_requestor_badge_names}")
     existing_requestor_trade_badges = [t for t in existing_requestor_badges if t in trade_requestor_badge_names]
     if len(existing_requestor_trade_badges) > 0:
       db_cancel_trade(active_trade)
@@ -300,10 +298,8 @@ class Trade(commands.Cog):
 
     requestee_badges = db_get_user_badge_names(active_trade["requestee_id"])
     existing_requestee_badges = [b["badge_name"].replace('_', ' ').replace('.png', '') for b in requestee_badges]
-    logger.info(f"existing_requestee_badges - {existing_requestee_badges}")
     trade_requestee_badges = db_get_trade_offered_badges(active_trade)
     trade_requestee_badge_names = [b["badge_name"] for b in trade_requestee_badges]
-    logger.info(f"trade_requestee_badge_names - {trade_requestee_badge_names}")
     existing_requestee_trade_badges = [t for t in existing_requestee_badges if t in trade_requestee_badge_names]
     if len(existing_requestee_trade_badges) > 0:
       db_cancel_trade(active_trade)

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -10,7 +10,7 @@ badge_data = json.loads(f.read())
 f.close()
 
 async def all_badges_autocomplete(ctx:discord.AutocompleteContext):
-  all_badges = [key.replace('_', '').replace('.png', '') for key in badge_data.keys()]
+  all_badges = [key.replace('_', ' ').replace('.png', '') for key in badge_data.keys()]
   return [badge for badge in all_badges if ctx.value.lower() in badge.lower()]
 
 @bot.slash_command(


### PR DESCRIPTION
If a trade was pending and had offered a user a badge, but that user acquired that badge in the meantime before it was accepted, the previous code would gift them the badge anyway when the badges were transfered. This resulted in users having two copies of the same badge.

This has now been fixed, and there is also a new admin-only gifting command `/gift_specific_badge` which can be used for testing this.