### PR TITLE
Fix: Correct Related Trades Cancelation

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.2.5
-appVersion: v1.2.5
+version: v1.2.6
+appVersion: v1.2.6


### PR DESCRIPTION
This PR shoud limit the cancelations to those that are actually related to the trades being done rather than across the board.