### PR TITLE
Fix: Correct Cancelation Query And Add Failsafes For Badge Trading

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.3.0
-appVersion: v1.3.0
+version: v1.3.1
+appVersion: v1.3.1


### PR DESCRIPTION
Danma rocks! New sexy (and correct!) query to locate all related trades that involve the requestor and requestee and the badges that are transfered in the active trade to cancel them.

Also added extra failsafes in case the requestor/requestee somehow received or removed the involved badges from their inventory in the intervening time.