### PR TITLE
Fix: Add Defers For Games, Add Private Option For Wordcloud, Misc Cleanup And Error Handling

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.3.3
-appVersion: v1.3.3
+version: v1.3.4
+appVersion: v1.3.4

--- a/cogs/trivia.py
+++ b/cogs/trivia.py
@@ -8,12 +8,12 @@ f = open(config["commands"]["trivia"]["data"])
 trivia_data = json.load(f)
 f.close()
 
-#    _____                                     __________        __    __                 
-#   /  _  \   ____   ________  _  __ __________\______   \__ ___/  |__/  |_  ____   ____  
-#  /  /_\  \ /    \ /  ___/\ \/ \/ // __ \_  __ \    |  _/  |  \   __\   __\/  _ \ /    \ 
+#    _____                                     __________        __    __
+#   /  _  \   ____   ________  _  __ __________\______   \__ ___/  |__/  |_  ____   ____
+#  /  /_\  \ /    \ /  ___/\ \/ \/ // __ \_  __ \    |  _/  |  \   __\   __\/  _ \ /    \
 # /    |    \   |  \\___ \  \     /\  ___/|  | \/    |   \  |  /|  |  |  | (  <_> )   |  \
 # \____|__  /___|  /____  >  \/\_/  \___  >__|  |______  /____/ |__|  |__|  \____/|___|  /
-#         \/     \/     \/              \/             \/                              \/ 
+#         \/     \/     \/              \/             \/                              \/
 categories = trivia_data["categories"]
 category_choices = []
 for category in categories.keys():
@@ -39,12 +39,12 @@ class AnswerButton(discord.ui.Button):
     await interaction.response.send_message(f"You guessed: **{self.answer_index + 1}** - {self.answer_text}", ephemeral=True)
 
 
-# ___________      .__      .__        
-# \__    ___/______|__|__  _|__|____   
-#   |    |  \_  __ \  \  \/ /  \__  \  
+# ___________      .__      .__
+# \__    ___/______|__|__  _|__|____
+#   |    |  \_  __ \  \  \/ /  \__  \
 #   |    |   |  | \/  |\   /|  |/ __ \_
 #   |____|   |__|  |__| \_/ |__(____  /
-#                                   \/ 
+#                                   \/
 class Trivia(commands.Cog):
   def __init__(self, bot):
     self.bot = bot
@@ -53,7 +53,7 @@ class Trivia(commands.Cog):
     self.trivia_answers = {}
     self.trivia_message = None
     self.trivia_running = False
-  
+
   def clear_data(self):
     self.trivia_data = {}
     self.trivia_answers = {}
@@ -87,6 +87,7 @@ class Trivia(commands.Cog):
   @tasks.loop(seconds=20,count=1)
   async def trivia_quiz(self, ctx:discord.ApplicationContext, category:str):
     try:
+      await ctx.defer()
       self.trivia_running = True
 
       if category:
@@ -121,14 +122,13 @@ class Trivia(commands.Cog):
         view.add_item(button)
 
       embed.set_footer(text="Select a button below with your answer!")
-      # channel = bot.get_channel(config["channels"]["quizzing-booth"])
-      self.trivia_message = await ctx.respond(
+      self.trivia_message = await ctx.followup.send(
         embed=embed,
         file=thumb,
         view=view
       )
     except Exception as e:
-      await ctx.respond(embed=discord.Embed(
+      await ctx.followup.send(embed=discord.Embed(
         title="Error Encountered with Trivia! Sorry, we're on it!",
         color=discord.Color.red(),
       ), ephemeral=True)
@@ -161,7 +161,7 @@ class Trivia(commands.Cog):
         else:
           incorrect_guessers.append(trivia_answer)
 
-      channel = bot.get_channel(config["channels"]["quizzing-booth"])
+      channel = bot.get_channel(config["channels"]["morns-nonstop-quiz"])
       embed = discord.Embed(
         title="Trivia Complete!",
         description="The correct answer was:\n\n**{}**: {} \n \n** **".format(self.trivia_data['correct_choice'] + 1, self.trivia_data["correct_answer"])
@@ -192,9 +192,7 @@ class Trivia(commands.Cog):
         increase_jackpot(reward)
 
       # Disable all the answer buttons now that the trivia session is over
-      original_message = await self.trivia_message.original_message()
-      if original_message != None:
-        await original_message.edit(view=None)
+      await self.trivia_message.edit(view=None)
 
       self.clear_data()
 

--- a/commands/wordcloud.py
+++ b/commands/wordcloud.py
@@ -20,25 +20,39 @@ image_masks = [
   description="Show your own most popular words in a wordcloud! Enable logging to be able to generate a cloud."
 )
 @option(
+  name="public",
+  description="Show to public?",
+  required=True,
+  choices=[
+    discord.OptionChoice(
+      name="No",
+      value="no"
+    ),
+    discord.OptionChoice(
+      name="Yes",
+      value="yes"
+    )
+  ]
+)
+@option(
   name="enable_logging",
   description="Enable message logging to be able to generate wordclouds",
   required=False,
   choices=[
     discord.OptionChoice(
       name="Yes - save words in my public messages to your database",
-      value="Yes"
+      value="yes"
     ),
     discord.OptionChoice(
       name="No - and please delete all my data",
-      value="No"
+      value="no"
     )
   ]
 )
-
-async def wordcloud(ctx:discord.ApplicationContext, enable_logging:str):
+async def wordcloud(ctx:discord.ApplicationContext, public:str, enable_logging:str):
 
   # handle logging toggle on/off
-  if enable_logging == "Yes":
+  if enable_logging == "yes":
     db = getDB()
     query = db.cursor(dictionary=True)
     sql = "UPDATE users SET log_messages = 1 WHERE discord_id = %s"
@@ -50,8 +64,8 @@ async def wordcloud(ctx:discord.ApplicationContext, enable_logging:str):
     await ctx.respond(content=f"Now logging your messages in the database! Once you have posted a few messages, check your wordcloud by typing `/wordcloud`! Disable logging and delete all your saved data by selecting \"No\" instead to /wordcloud.", ephemeral=True)
     logger.info(f"{Style.BRIGHT}{ctx.author.display_name}{Style.RESET_ALL} has {Fore.GREEN}enabled{Fore.RESET} {Fore.CYAN}message logging!{Fore.RESET}")
     return
-  
-  if enable_logging == "No":
+
+  if enable_logging == "no":
     db = getDB()
     query = db.cursor(dictionary=True)
     sql = "UPDATE users SET log_messages = 0 WHERE discord_id = %s"
@@ -74,8 +88,10 @@ async def wordcloud(ctx:discord.ApplicationContext, enable_logging:str):
   if user["log_messages"] and user["log_messages"] != 1:
     await ctx.respond(content="You do not have logging enabled. Use `/wordcloud enable_logging Yes` to start logging so AGIMUS can generate a wordcloud for you!", ephemeral=True)
     return
-  
-  await ctx.defer()
+
+  public = bool(public == "yes")
+
+  await ctx.defer(ephemeral=not public)
   # get their message data
   user_details = get_wordcloud_text_for_user(ctx.author.id)
 
@@ -91,7 +107,7 @@ async def wordcloud(ctx:discord.ApplicationContext, enable_logging:str):
   full_wordlist = " ".join(full_wordlist)
   remove_emoji = re.compile('<.*?>')
   special_chars = re.escape(string.punctuation)
-  
+
   full_wordlist = re.sub(remove_emoji, '', full_wordlist) # strip discord emoji from message
   full_wordlist = re.sub(r'https?:\/\/\S*', '', full_wordlist) # strip all URLs from the content
   full_wordlist = re.sub(r'['+special_chars+']', '', full_wordlist) # strip any remaining special characters
@@ -99,28 +115,28 @@ async def wordcloud(ctx:discord.ApplicationContext, enable_logging:str):
   command_words = ["profile", "help", "wordcloud", "quiz", "trivia", "slots", "poker", "set_tagline", "reports", "badges"]
   for word in command_words:
     STOPWORDS.add(word)
-  
+
   # mask image (combadge in this case, something else might work better)
   mask = np.array(random.choice(image_masks))
 
   # build wordcloud with magic of wordcloud lib
   wc = WordCloud(
-    scale=1, 
-    contour_color="#000000", 
-    color_func=lambda *args, **kwargs: random.choice(["#ffaa00", "#33cc99", "#ff2200", "#ff9966", "#cc33ff"]), 
+    scale=1,
+    contour_color="#000000",
+    color_func=lambda *args, **kwargs: random.choice(["#ffaa00", "#33cc99", "#ff2200", "#ff9966", "#cc33ff"]),
     contour_width=1,
     min_font_size=8,
-    max_words=500, 
-    stopwords=STOPWORDS, 
+    max_words=500,
+    stopwords=STOPWORDS,
     mask=mask,
-    font_path="./fonts/tng_credits.ttf", 
-    background_color="#000000", 
-    mode="RGB", 
-    width=1200, 
-    height=800, 
+    font_path="./fonts/tng_credits.ttf",
+    background_color="#000000",
+    mode="RGB",
+    width=1200,
+    height=800,
     min_word_length=3).generate(full_wordlist)
 
-  # create PIL image 
+  # create PIL image
   image = wc.to_image()
   image.save(f"./images/reports/wordcloud-{user_details['name']}.png")
 
@@ -128,7 +144,7 @@ async def wordcloud(ctx:discord.ApplicationContext, enable_logging:str):
   discord_image = discord.File(f"./images/reports/wordcloud-{user_details['name']}.png")
 
   # send the image!
-  await ctx.followup.send(content=f"(Based on your last {user_details['num_messages']} messages)", file=discord_image, ephemeral=False)
+  await ctx.followup.send(content=f"(Based on your last {user_details['num_messages']} messages)", file=discord_image, ephemeral=not public)
   logger.info(f"{Style.BRIGHT}{ctx.author.display_name}{Style.RESET_ALL} has generated a {Fore.CYAN}wordcloud!{Fore.RESET}")
 
 # get user's message history and return it in a dict


### PR DESCRIPTION
Adds defers for both Slots and Trivia (sorry @jp00p  I didn't actually see you had added one for slots yet, but I think this version is actually sightly cleaner and doesn't require us to pull in the channel since we can do it on a second non-ephemeral followup!)

Adds a private flag for Wordcloud

Handles some error cases better, specifically when Trivia fails out and prevents the bot from stopping up due to 503s or JSON data error from opentdb.com. We also don't log application command access check exceptions anymore.