### PR TITLE
DB Backup/Restore POC

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -24,6 +24,10 @@ export DB_ROOT_PASSWORD=password
 export DB_USER=root
 export DB_DUMP_FILENAME=bot-dump.sql
 export DB_CONTAINER_NAME=fodmysql
+export DB_BACKUP_DEPLOY_KEY=Tm90IGFjdHVhbGx5IGEgcHJpdmF0ZSBrZXkuLi4g8J+ZhAo=
+export DB_BACKUP_SUB_DIR=agimus
+export DB_BACKUP_GITHUB_USER=
+export DB_BACKUP_GITHUB_EMAIL=
 
 # Path to configuration json
 export BOT_CONTAINER_NAME=agimus

--- a/.github/workflows/pr-test-and-build.yaml
+++ b/.github/workflows/pr-test-and-build.yaml
@@ -97,8 +97,9 @@ jobs:
           sleep 5
           echo "Delete (restart) AGIMUS pod now that MySQL should be running and seeded..."
           kubectl --namespace agimus delete pod $(kubectl --namespace agimus get pods | grep agimus | awk '{print $1}') || true
+          sleep 3
           echo "If after 20 seconds the string 'BOT IS ONLINE AND READY FOR COMMANDS' is not present in the logs, the test has failed..."
-          sleep 20
+          timeout 20s kubectl --namespace agimus logs -f $(kubectl --namespace agimus get pods | grep agimus | awk '{print $1}') || true
           bash_test="$(kubectl --namespace agimus logs $(kubectl --namespace agimus get pods | grep agimus | awk '{print $1}') | grep 'BOT IS ONLINE AND READY FOR COMMANDS')"
           echo "$bash_test"
           if [[ -n "$bash_test" ]]; then
@@ -127,7 +128,7 @@ jobs:
           echo "Configmaps:"
           kubectl --namespace agimus get configmaps
           echo "Agimus Config:"
-          kubectl --namespace agimus get configmaps agimus-config -o yaml
+          kubectl --namespace agimus get configmaps agimus-config -o jsonpath='{.data.local\.json}' | jq '.' || true
           echo "Describe Agimus pod:"
           kubectl --namespace agimus describe pod $(kubectl --namespace agimus get pods | grep agimus | awk '{print $1}') || true
           echo "Logs:"

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ images/slot_results/*.png
 images/trades/*.png
 !images/slot_results/template*
 !images/profiles/template*
+database/*
+database

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:20.04
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        curl wget apt-utils python3 python3-pip make build-essential locales openssl git jq tzdata sudo lsb-release \
+        curl wget apt-utils python3 python3-pip make build-essential locales openssl git jq tzdata sudo lsb-release mysql-client \
     && touch /etc/sudoers.d/bot-user \
     && echo "bot ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/bot-user \
     && useradd -ms /bin/bash bot \

--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.3.5
-appVersion: v1.3.5
+version: v1.3.6
+appVersion: v1.3.6


### PR DESCRIPTION
# DB Backup/Restore POC

This should also fix inconsistencies with the `db-*` makefile targets by standardizing calls from the agimus container, and not the mysql container. 

## Setup

To run these commands, you must first set up a deploy key for the [database private repo](https://github.com/Friends-of-DeSoto/database) by following the instructions in the read-me. Once the deploy key has been added to github and your .env file, the new makefile targets will work by executing them inside the container.

## Backup

First exec into the agimus pod and run the makefile target `db-backup`

```bash
% make docker-exec 
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

bot@a5de87966440:/bot$ make db-backup
mkdir -p /home/bot/.ssh
chmod 600 /home/bot/.ssh/id_ed25519
git config --global user.name mathew-fleisch
git config --global user.email mathew.fleisch@gmail.com
ssh-keyscan github.com >> /home/bot/.ssh/known_hosts
# github.com:22 SSH-2.0-babeld-b9c2a189
# github.com:22 SSH-2.0-babeld-b9c2a189
# github.com:22 SSH-2.0-babeld-b9c2a189
# github.com:22 SSH-2.0-babeld-b9c2a189
# github.com:22 SSH-2.0-babeld-b9c2a189
Dumping db to ./bot-dump.sql
mysqldump: [Warning] Using a password on the command line interface can be insecure.
git clone git@github.com:Friends-of-DeSoto/database.git
Cloning into 'database'...
Warning: Permanently added the ECDSA host key for IP address '192.30.255.113' to the list of known hosts.
remote: Enumerating objects: 33, done.
remote: Counting objects: 100% (33/33), done.
remote: Compressing objects: 100% (18/18), done.
remote: Total 33 (delta 8), reused 28 (delta 6), pack-reused 0
Receiving objects: 100% (33/33), 47.95 KiB | 246.00 KiB/s, done.
Resolving deltas: 100% (8/8), done.
cp ./bot-dump.sql database/lal/agimus.sql
cd database \
        && git add lal/agimus.sql \
        && git commit -m "Backup AGIMUS DB: lal Thu 28 Jul 2022 06:49:40 PM PDT" \
        && git push origin main
[main c9ddd8a] Backup AGIMUS DB: lal Thu 28 Jul 2022 06:49:40 PM PDT
 1 file changed, 9 insertions(+), 10 deletions(-)
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 6 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (4/4), 955 bytes | 14.00 KiB/s, done.
Total 4 (delta 2), reused 0 (delta 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To github.com:Friends-of-DeSoto/database.git
   cf07166..c9ddd8a  main -> main
```

## Restore

To restore from a specific backup, set the `DB_BACKUP_RESTORE_COMMIT` env var, and run the `db-restore` makefile target. Get commit hashes from the [commits page](https://github.com/Friends-of-DeSoto/database/commits/main)

Example: `DB_BACKUP_RESTORE_COMMIT=cf0716622f632a015bda64ca81459a78d7770782 make db-restore`

```bash
% make docker-exec
To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

bot@a5de87966440:/bot$ DB_BACKUP_RESTORE_COMMIT=cf0716622f632a015bda64ca81459a78d7770782 make db-restore
/home/bot/.ssh/id_ed25519 - ssh key already exists. skipping git setup...
git clone git@github.com:Friends-of-DeSoto/database.git \
        && cd database \
        && git reset --hard cf0716622f632a015bda64ca81459a78d7770782
Cloning into 'database'...
remote: Enumerating objects: 41, done.
remote: Counting objects: 100% (41/41), done.
remote: Compressing objects: 100% (22/22), done.
remote: Total 41 (delta 12), reused 34 (delta 8), pack-reused 0
Receiving objects: 100% (41/41), 49.12 KiB | 322.00 KiB/s, done.
Resolving deltas: 100% (12/12), done.
HEAD is now at cf07166 Update AGIMUS DB: lal Thu 28 Jul 2022 05:51:12 AM PDT
cp database/lal/agimus.sql ./bot-dump.sql
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
```