### PR TITLE
Feature: `/set_profile_badge`

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.3.14
-appVersion: v1.3.14
+version: v1.3.15
+appVersion: v1.3.15

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -1,5 +1,5 @@
 from common import *
-from utils.badge_utils import generate_badge_trade_showcase
+from utils.badge_utils import generate_badge_trade_showcase, db_get_user_badge_names
 from utils.check_channel_access import access_check
 
 f = open("./data/rules_of_acquisition.txt", "r")
@@ -1306,18 +1306,6 @@ def db_remove_badge_from_trade_request(active_trade, badge_name):
   db.commit()
   query.close()
   db.close()
-
-def db_get_user_badge_names(discord_id):
-  db = getDB()
-  query = db.cursor(dictionary=True)
-  sql = "SELECT badge_name FROM badges WHERE user_discord_id = %s"
-  vals = (discord_id,)
-  query.execute(sql, vals)
-  badge_names = query.fetchall()
-  db.commit()
-  query.close()
-  db.close()
-  return badge_names
 
 def db_get_active_requestee_trades(requestee_id):
   db = getDB()

--- a/common.py
+++ b/common.py
@@ -191,9 +191,16 @@ def get_user(discord_id:int):
   vals = (discord_id,)
   query.execute(sql, vals)
   user_stickers = query.fetchall()
+  # get user featured badges
+  sql = "SELECT badge_name FROM profile_badges WHERE user_discord_id = %s AND badge_name IS NOT NULL"
+  vals = (discord_id,)
+  query.execute(sql, vals)
+  user_badges = query.fetchall()
+  # close db
   query.close()
   db.close()
   user_data["stickers"] = user_stickers
+  user_data["badges"] = user_badges
   logger.debug(f"USER DATA: {user_data}")
   return user_data
 

--- a/data/seed-db.sql
+++ b/data/seed-db.sql
@@ -51,6 +51,14 @@ CREATE TABLE IF NOT EXISTS profile_taglines (
   PRIMARY KEY (id),
   UNIQUE KEY (user_discord_id)
 );
+CREATE TABLE IF NOT EXISTS profile_badges (
+  id int(11) NOT NULL AUTO_INCREMENT,
+  user_discord_id VARCHAR(64) NOT NULL,
+  badge_name VARCHAR(255) DEFAULT NULL,
+  last_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY (user_discord_id)
+);
 CREATE TABLE IF NOT EXISTS trades (
   id int(11) NOT NULL AUTO_INCREMENT,
   requestor_id varchar(128) NOT NULL,

--- a/utils/badge_utils.py
+++ b/utils/badge_utils.py
@@ -292,3 +292,26 @@ def db_get_badge_count_for_user(user_id):
   db.close()
 
   return result['count(*)']
+
+def db_get_user_badge_names(user_id):
+  db = getDB()
+  query = db.cursor(dictionary=True)
+  sql = "SELECT badge_name FROM badges WHERE user_discord_id = %s"
+  vals = (user_id,)
+  query.execute(sql, vals)
+  badge_names = query.fetchall()
+  db.commit()
+  query.close()
+  db.close()
+  return badge_names
+
+def db_remove_user_profile_badge(user_id):
+  db = getDB()
+  query = db.cursor()
+  sql = "REPLACE INTO profile_badges (tagline, user_discord_id) VALUES (%(badge_name)s, %(user_discord_id)s)"
+  vals = {"badge_name" : "", "user_discord_id" : user_id}
+  logger.info(f"CLEARING PROFILE BADGE {sql}")
+  query.execute(sql, vals)
+  db.commit()
+  query.close()
+  db.close()


### PR DESCRIPTION
Allow users to select one of the badges from their inventory to add to their profile!

![image](https://user-images.githubusercontent.com/1075211/182080722-5108cfcf-c82d-45ae-91a6-44ee2a5fb635.png)

![image](https://user-images.githubusercontent.com/1075211/182080733-c0856436-390c-42b4-8ff9-84f4513a315b.png)

![image](https://user-images.githubusercontent.com/1075211/182080745-dcb3c2ae-6556-4202-82e8-ab0cc9e30623.png)

If they have traded the badge away, it will be cleared on their next `/profile` and they'll receive a DM:

![image](https://user-images.githubusercontent.com/1075211/182080823-7138d5db-835e-48e3-aae7-614869686060.png)

They can also clear their current badge with the `[CLEAR BADGE]` option.

![image](https://user-images.githubusercontent.com/1075211/182081316-68601c5f-0343-4c3a-bb91-6cfb86679356.png)


