### PR TITLE
Fix: Need To Use Await For New Badge Trade Image Threading

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.3.18
-appVersion: v1.3.18
+version: v1.3.19
+appVersion: v1.3.19

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -902,7 +902,7 @@ class Trade(commands.Cog):
     offered_badges = db_get_trade_offered_badges(active_trade)
     offered_badge_filenames = [f"{b['badge_name'].replace(' ', '_')}.png" for b in offered_badges]
     offered_image_id = f"{active_trade['id']}-offered"
-    offered_image = generate_badge_trade_showcase(
+    offered_image = await generate_badge_trade_showcase(
       offered_badge_filenames,
       offered_image_id,
       f"Badge(s) Offered by {requestor.display_name}",
@@ -924,7 +924,7 @@ class Trade(commands.Cog):
     requested_badges = db_get_trade_requested_badges(active_trade)
     requested_badge_filenames = [f"{b['badge_name'].replace(' ', '_')}.png" for b in requested_badges]
     requested_image_id = f"{active_trade['id']}-requested"
-    requested_image = generate_badge_trade_showcase(
+    requested_image = await generate_badge_trade_showcase(
       requested_badge_filenames,
       requested_image_id,
       f"Badge(s) Requested from {requestee.display_name}",

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -432,7 +432,7 @@ async def send_badge_reward_message(message:str, embed_description:str, embed_ti
   embed_description += f"\n{star_str}\n"
   embed=discord.Embed(title=embed_title, description=embed_description, color=discord.Color.random())
   embed.set_thumbnail(url=thumbnail_image)
-  embed.set_footer(text="See all your badges by typing /badges - disable this by typing /disable_xp")
+  embed.set_footer(text="See all your badges by typing '/badges showcase' - disable this by typing '/disable_xp'")
   if badge_info:
     embed.set_image(url=f"{badge_info['image_url']}")
     await channel.send(content=message, embed=embed)

--- a/data/drops.json
+++ b/data/drops.json
@@ -119,6 +119,11 @@
     "description": "Get that gold pressed latinum. Am I right?",
     "url": "https://i.imgur.com/jrV65iz.mp4"
   },
+  "Gonna Need A Lockdown": {
+    "file": "data/drops/gonnaneedalockdown.mp4",
+    "description": "Adam Gonna Need A Lockdown Song",
+    "url": "https://i.imgur.com/5jcMZg8.mp4"
+  },
   "Gul Dukat, Gul Dukat, Gul Dukat": {
     "file": "data/drops/guldukat.mp4",
     "description": "Gul Dukat",
@@ -228,6 +233,11 @@
     "file": "data/drops/picardnooo.mp4",
     "description": "Picard: Nooo! No! Glass Crashing",
     "url": "https://i.imgur.com/1LK0Oa2.mp4"
+  },
+  "Picard's A Borg!": {
+    "file": "data/drops/picardsaborg.mp4",
+    "description": "He's a borg oh no ahh picard's a borg",
+    "url": "https://i.imgur.com/4Trg2O4.mp4"
   },
   "Planning A Heist? Gold!": {
     "file": "data/drops/fortknox.mp4",


### PR DESCRIPTION
Big bug I missed, this has been causing the badge trade images that preview the badges that are going to be transfered to fail out. 🤦 

I also threw in two drops while I was here that needed to go up.