### PR TITLE
Role reaction cleanup

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.4.21
-appVersion: v1.4.21
+version: v1.4.22
+appVersion: v1.4.22

--- a/cogs/react_roles.py
+++ b/cogs/react_roles.py
@@ -1,3 +1,4 @@
+from distutils.command.build import build
 from common import *
 
 class ReactRoles(commands.Cog):
@@ -17,6 +18,7 @@ class ReactRoles(commands.Cog):
   async def on_ready(self):
     self.roles_channel = self.bot.get_channel(config["channels"]["roles-and-pronouns"])
     self.reaction_roles = self.load_role_reactions() # gather all our data for reactions
+    await self.rebuild_embeds.start()
 
   # listen to raw reaction additions
   @commands.Cog.listener()
@@ -26,14 +28,20 @@ class ReactRoles(commands.Cog):
     if payload.channel_id == self.roles_channel.id:
       await self.parse_reaction(payload)
 
+  # listen to raw reaction removals
+  @commands.Cog.listener()
+  async def on_raw_reaction_remove(self, payload:discord.RawReactionActionEvent):
+    if payload.channel_id == self.roles_channel.id:
+      await self.parse_reaction(payload)
+
   # build reaction role dict for handling reacts
   def load_role_reactions(self):
     response = {}
-    for rdb in self.reaction_db_data:
+    for rdb in self.get_reaction_db_data():
       if rdb["reaction_type"]:
         message_id = rdb["message_id"]
         message_name = rdb["message_name"]
-        response[message_id] = { "reactions": {}, "reaction_type": rdb["reaction_type"] }
+        response[message_id] = { "reactions": {}, "reaction_type": rdb["reaction_type"], "message_name": message_name }
         # loop over json and pull out emoji:role
         for rr in self.reaction_data[message_name]["reactions"]:
           response[message_id]["reactions"][rr["emoji"]] = discord.utils.get(bot.guilds[0].roles,name=rr["role"])
@@ -42,18 +50,20 @@ class ReactRoles(commands.Cog):
   # handle a reaction, either add or remove roles when a user reacts
   async def parse_reaction(self, payload:discord.RawReactionActionEvent):
     user = self.bot.guilds[0].get_member(payload.user_id)
+    user_info = get_user(user.id)
     message = self.roles_channel.get_partial_message(payload.message_id)
-    await message.remove_reaction(payload.emoji, user) # remove their reaction immediately
-    data = self.reaction_roles.get(str(payload.message_id))
+    data = self.reaction_roles[str(message.id)]
+    message_name = data["message_name"]
     reaction_type = data.get("reaction_type")
     role = data["reactions"].get(str(payload.emoji))
-
     if user and role:
+      user_dm_message = ""
       # user is valid and we found a valid role associated with the reaction
-      if user.get_role(role.id) == None:
+      if user.get_role(role.id) == None and payload.event_type == "REACTION_ADD":
         logger.info(f"Adding role {role.name} to {user.display_name}!")
         # add role!
         await user.add_roles(role, reason="ReactionRole")
+        user_dm_message = f"You have __added__ the role **{payload.emoji} {role.name}** to your profile on the USS Hood!"
         if reaction_type == "single":
           # if its a single type reaction, remove all other associated roles
           roles_to_remove = []
@@ -62,11 +72,19 @@ class ReactRoles(commands.Cog):
               roles_to_remove.append(rr)
           if len(roles_to_remove) > 0:
             await user.remove_roles(*roles_to_remove, reason="ReactionRole")
+            user_dm_message += f"\n> This has removed other roles in that same category automatically. Magic!"
       else:
-        # they already have the role, remove it!
-        if user.get_role(role.id) != None:
-          await user.remove_roles(role, reason="ReactionRole")
-
+          # they already have the role, remove it!
+          if user.get_role(role.id) != None and payload.event_type == "REACTION_REMOVE":
+            logger.info(f"Removing {role.name} from {user.display_name}!")
+            await user.remove_roles(role, reason="ReactionRole")
+            user_dm_message = f"You have __removed__ the role **{payload.emoji} {role.name}** from your profile on the USS Hood!"
+      if user_dm_message != "" and user_info["receive_notifications"]:
+        if random.choice([0,1,2]) == 1:
+          user_dm_message += f"\n\n(PS. Use `/settings` in the server to disable these DMs if you need to.)"
+        await user.send(user_dm_message)
+      
+        
 
   # updates db with new message details and deletes old messages from db
   def store_reaction_data(self, header_id, message_id, message_name, reaction_type):
@@ -91,6 +109,7 @@ class ReactRoles(commands.Cog):
       db.commit()
       query.close()
     db.close()
+    self.reaction_roles = self.load_role_reactions()
     
   # add initial reactions to message
   async def add_role_reactions(self, message, reacts):
@@ -105,7 +124,6 @@ class ReactRoles(commands.Cog):
     query = db.cursor(dictionary=True)
     query.execute(sql)
     reaction_data = query.fetchall()
-    db.commit()
     query.close()
     db.close()
     return reaction_data
@@ -126,7 +144,7 @@ class ReactRoles(commands.Cog):
         else:
           if message:
             logger.info(f"Deleting old role message {message.id}")
-            await message.delete()      
+            await message.delete()  
     
     # loop over all the reaction data and build out the messages
     for message_name, p in self.reaction_data.items():
@@ -139,50 +157,63 @@ class ReactRoles(commands.Cog):
 
       # build the embed
       if p.get("embed"):
-        embed_description = p["embed"]["description"]
-        if p.get("embed_channel_name_placeholder"):
-          # add channel name mention to embed if there is one
-          channel_string = f"<#{get_channel_id(config['channels'][p['embed_channel_name_placeholder']])}>"
-          embed_description = embed_description.format(channel_string)
-        embed = discord.Embed(
-          title=p["embed"]["title"],
-          description=f'{embed_description}',
-          color=discord.Color.from_rgb(251, 112, 5)
-        )
-        embed.set_thumbnail(url=p["thumbnail_url"])
-        list_of_reactions = []
-
-        if len(p["reactions"]) > 0:
-          for reaction in p["reactions"]:
-            role = discord.utils.get(ctx.guild.roles,name=reaction["role"])
-            embed_desc = f'{reaction["emoji"]} for {role.mention}'
-            if reaction.get("description"):
-              embed_desc += f"\n{reaction['description']}\n"
-            list_of_reactions.append(embed_desc)
-          # one field with lots of content and a blank name
-          embed.add_field(
-            name="⠀",
-            value="\n".join(list_of_reactions),
-            inline=False
-          )
-        embed.set_footer(text=p["embed"]["footer"])
+        embed = self.build_react_embed(p)
         # send the message
         react_role_msg = await self.roles_channel.send(content=message_content, embed=embed)
       
       # save some of the message details to the database
       self.store_reaction_data(header_msg.id, react_role_msg.id, message_name, p["reaction_type"])
-
+      self.reaction_roles = self.load_role_reactions()
       # add the reactions to the message
-      await self.add_role_reactions(react_role_msg, p["reactions"])
-    
+      await self.add_role_reactions(react_role_msg, p["reactions"])    
     # update role reactions dict
     self.role_reactions = self.load_role_reactions()
-    # reload db data
-    self.reaction_db_data = self.get_reaction_db_data()
 
   @q_update_role_messages.error
-  async def q_update_role_messages_error(ctx, error):
+  async def q_update_role_messages_error(self, ctx, error):
     if isinstance(error, commands.MissingPermissions):
       await ctx.respond("You think you're clever!", ephemeral=True)
     else:
       await ctx.respond("Sensoars indicate some kind of ...*error* has occured!", ephemeral=True)
+
+  # builds and returns the embed for the current reaction post
+  def build_react_embed(self, post):
+    embed = None
+    embed_description = post["embed"]["description"]
+    if post.get("embed_channel_name_placeholder"):
+      # add channel name mention to embed if there is one
+      channel_string = f"<#{get_channel_id(config['channels'][post['embed_channel_name_placeholder']])}>"
+      embed_description = embed_description.format(channel_string)
+    embed = discord.Embed(
+      title=post["embed"]["title"],
+      description=f'{embed_description}',
+      color=discord.Color.from_rgb(251, 112, 5)
+    )
+    embed.set_thumbnail(url=post["thumbnail_url"])
+    list_of_reactions = []
+
+    if len(post["reactions"]) > 0:
+      for reaction in post["reactions"]:
+        role = discord.utils.get(bot.guilds[0].roles,name=reaction["role"])
+        embed_desc = f'{reaction["emoji"]} for {role.mention} ({len(role.members)})'
+        if reaction.get("description"):
+          embed_desc += f"\n{reaction['description']}\n"
+        list_of_reactions.append(embed_desc)
+      # one field with lots of content and a blank name
+      embed.add_field(
+        name="⠀",
+        value="\n".join(list_of_reactions),
+        inline=False
+      )
+    embed.set_footer(text=post["embed"]["footer"])
+    return embed
+
+  # rebuild embeds (so role counts update)
+  @tasks.loop(seconds=20)
+  async def rebuild_embeds(self):
+    rr = self.reaction_roles
+    for message_id in rr:
+      message_name = rr[message_id]["message_name"]
+      message = self.roles_channel.get_partial_message(message_id)
+      new_embed = self.build_react_embed(self.reaction_data[message_name]) # rebuild the embed
+      await message.edit(embed=new_embed)

--- a/common.py
+++ b/common.py
@@ -339,7 +339,7 @@ def increase_jackpot(amt):
 # This runs to apply the local channel list on top of the existing channel config
 def generate_local_channel_list(client):
   if client.guilds[0]:
-    channels = client.guilds[0].channels + client.guilds[0].threads + client.guilds[0].voice_channels
+    channels = client.guilds[0].channels + client.guilds[0].threads + client.guilds[0].voice_channels + client.guilds[0].forum_channels
     channel_list = {}
     for channel in channels:
       channel_name = channel.name.encode("ascii", errors="ignore").decode().strip()

--- a/configuration.json
+++ b/configuration.json
@@ -719,6 +719,7 @@
   ],
   "roles": {
     "agimus_maintainers": "AGIMUS Acolyte",
+    "reaction_roles_enabled": true,
     "promotion_roles": {
       "required_rank_xp": {
         "cadet": 10,

--- a/data/react_roles/departments.json
+++ b/data/react_roles/departments.json
@@ -6,7 +6,7 @@
   "embed" : {
     "title": "Add color and an icon to your name!",
     "description": "Choose your department to make your name that color, and you'll also get a little icon! This is just for fun, you will not be required to do any work aboard the starship if you choose a department.\n\nYou can only be in one department at a time, but you can change it at any time.",
-    "footer": "React to the emoji below to select your department and change your name color."
+    "footer": "React to the emoji below to add/remove your department and change your name color.\nIf you already have the role but your react hasn't been added yet, add then remove the reaction to remove the role!"
   },
   "reactions": [
     {

--- a/data/react_roles/locations.json
+++ b/data/react_roles/locations.json
@@ -6,7 +6,7 @@
   "embed" : {
     "title": "Add your location to your profile!",
     "description": "Use these roles to add your general location to your profile! You can add multiple locations if it makes sense.\n\nPlease leave us a message in {} if you don't see a location that fits for you.",
-    "footer": "React to the emoji below to add/remove the corresponding location."
+    "footer": "React to the emoji below to add/remove the corresponding location.\nIf you already have the role but your react hasn't been added yet, add then remove the reaction to remove the role!"
   },
   "embed_channel_name_placeholder": "captains-suggestion-box",
   "reactions": [

--- a/data/react_roles/notifications.json
+++ b/data/react_roles/notifications.json
@@ -6,7 +6,7 @@
   "embed" : {
     "title": "Get notified about different server events!",
     "description": "Use these roles to choose what kind of notifications you get. Everyone will be notified when Greatest Trek events are happening, as well as other server updates.\n\nYou can choose as many of these as you like, and you can change these at any time.",
-    "footer": "React to the emoji below to add/remove the corresponding notification type."
+    "footer": "React to the emoji below to add/remove the corresponding notification type.\nIf you already have the role but your react hasn't been added yet, add then remove the reaction to remove the role!"
   },
   "reactions": [
     {

--- a/data/react_roles/pronouns.json
+++ b/data/react_roles/pronouns.json
@@ -6,7 +6,7 @@
   "embed" : {
     "title": "Add pronouns to your profile!",
     "description": "Feel free to add as many as you like. You can change these at any time.\n\nVisit {} if you have any suggestions or feedback.",
-    "footer": "React to the emoji below to add/remove the corresponding pronoun."
+    "footer": "React to the emoji below to add/remove the corresponding pronoun.\nIf you already have the role but your react hasn't been added yet, add then remove the reaction to remove the role!"
   },
   "embed_channel_name_placeholder": "captains-suggestion-box",
   "reactions": [

--- a/main.py
+++ b/main.py
@@ -54,8 +54,9 @@ bot.add_cog(Settings(bot))
 bot.add_cog(Shop(bot))
 bot.add_cog(Slots(bot))
 bot.add_cog(Trade(bot))
-bot.add_cog(ReactRoles(bot))
 bot.add_cog(Backups(bot))
+if config["roles"]["reaction_roles_enabled"]:
+  bot.add_cog(ReactRoles(bot))
 
 
 ## Trivia relies on an external JSON request which might fail, in that case log the error but continue


### PR DESCRIPTION
- AGIMUS will now DM a user when they add/remove a role (can be disabled in settings, AGIMUS will remind them in the DMs sometimes)
- Reactions will stick around now, no longer auto-removes reactions
- Entire React roles cog can be disabled in configuration.json
- Embeds on messages will show role member counts
- Added task to update embeds every 20 sec (it can cause problems with api rates if users spam roles, this is my solution)