### PR TITLE
Fix: Register Users To DB On Join And On Typing

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.5.0
-appVersion: v1.5.0
+version: v1.5.1
+appVersion: v1.5.1

--- a/main.py
+++ b/main.py
@@ -230,7 +230,14 @@ async def on_raw_reaction_add(payload):
   if payload.event_type == "REACTION_ADD":
     await handle_starboard_reactions(payload)
 
-# listen to server leave events
+# listen to server join/leave events
+@bot.event
+async def on_member_join(member):
+  # Register user if they haven't been previously
+  if int(member.id) not in ALL_USERS:
+    logger.info(f"{Fore.LIGHTMAGENTA_EX}{Style.BRIGHT}New User{Style.RESET_ALL}{Fore.RESET}")
+    ALL_USERS.append(register_user(member))
+
 @bot.event
 async def on_member_remove(member):
   await show_leave_message(member)
@@ -259,6 +266,8 @@ async def on_guild_channel_update(before, after):
 @bot.event
 async def on_application_command(ctx):
   # Register user if they haven't been previously
+  # Note this occurrs _after_ the command has been executed,
+  # so we should primarily rely on registration through `on_member_join`
   if int(ctx.author.id) not in ALL_USERS:
     logger.info(f"{Fore.LIGHTMAGENTA_EX}{Style.BRIGHT}New User{Style.RESET_ALL}{Fore.RESET}")
     ALL_USERS.append(register_user(ctx.author))


### PR DESCRIPTION
Ran into an issue while testing the scrapper where the user hadn't been registered to the DB yet. Sadly we can't rely on the `on_application_command_*` events because those only occur _after_ the command is executed. To add another layer to help combat this, we can also register users whenever they join the server initially.