### PR TITLE
Fix: Filter Out ALL The Special Badges From Badge Statistics

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.5.2
-appVersion: v1.5.2
+version: v1.5.3
+appVersion: v1.5.3

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -189,7 +189,7 @@ class Trade(commands.Cog):
     # We only allow requestees to have n trades pending for managability's sake
     self.max_trades = 3
     self.max_badges_per_trade = 6
-    self.untradeable_badges = SPECIAL_BADGE_NAMES
+    self.untradeable_badges = [b['badge_name'] for b in SPECIAL_BADGES]
     self.trade_buttons = [
       pages.PaginatorButton("prev", label="    ⬅     ", style=discord.ButtonStyle.primary, row=1),
       pages.PaginatorButton(

--- a/utils/badge_utils.py
+++ b/utils/badge_utils.py
@@ -5,7 +5,16 @@ import math
 
 from common import *
 
-SPECIAL_BADGE_NAMES = ["Friends Of DeSoto", "Captain Picard Day"]
+SPECIAL_BADGES = [
+  {
+    "badge_name": "Friends Of DeSoto",
+    "badge_filename": "Friends_Of_DeSoto.png"
+  },
+  {
+    "badge_name": "Captain Picard Day",
+    "badge_filename": "Captain_Picard_Day.png"
+  }
+]
 
 # ___________.__                              .___.__
 # \__    ___/|  |_________   ____ _____     __| _/|__| ____    ____


### PR DESCRIPTION
We can now use `SPECIAL_BADGES` to define both the `badge_name` and `badge_filename` for the special badges we don't want traded/scrapped or listed in the badges statistics and it make happen good now.