### PR TITLE
Move from block list to allow list for loudbot and disable emoji triggers

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.6.6
-appVersion: v1.6.6
+version: v1.6.7
+appVersion: v1.6.7

--- a/configuration.json
+++ b/configuration.json
@@ -13,19 +13,14 @@
     },
     "loudbot": {
       "enabled": true,
-      "blocked_channels": [
-        "neelixs-morale-office",
-        "plasma-vent",
-        "counselor-trois-office",
-        "heuristic-associative-pathways",
-        "mo-pips-mo-problemz",
+      "allowed_channels": [
+        "after-dinner-conversation",
+        "badgeys-badges",
+        "bahrats-bazaar",
         "megalomaniacal-computer-storage",
-        "bot-logs",
-        "bot-setup",
-        "dabo-table",
-        "poker-night",
-        "morns-nonstop-quiz",
-        "badgeys-badges"
+        "seskas-catfishing-channel",
+        "ten-forward",
+        "temba-his-arms-wide"
       ]
     },
     "save_message": {

--- a/configuration.json
+++ b/configuration.json
@@ -17,7 +17,12 @@
         "after-dinner-conversation",
         "badgeys-badges",
         "bahrats-bazaar",
+        "dabo-table",
+        "dr-crushers-hotbox",
         "megalomaniacal-computer-storage",
+        "morns-nonstop-quiz",
+        "poker-night",
+        "robot-diagnostics",
         "seskas-catfishing-channel",
         "ten-forward",
         "temba-his-arms-wide"

--- a/handlers/loudbot.py
+++ b/handlers/loudbot.py
@@ -16,8 +16,8 @@ async def handle_loudbot(message:discord.Message):
   if not config["handlers"]["loudbot"]["enabled"]:
     return
 
-  blocked_channels = get_channel_ids_list(config["handlers"]["loudbot"]["blocked_channels"])
-  if message.channel.id in blocked_channels:
+  allowed_channels = get_channel_ids_list(config["handlers"]["loudbot"]["allowed_channels"])
+  if message.channel.id not in allowed_channels:
     return
 
   if is_loud(message.content):

--- a/utils/string_utils.py
+++ b/utils/string_utils.py
@@ -31,7 +31,7 @@ def strip_punctuation(string):
 # After stripping out allowed characters, return if the remaining string is uppercase or not
 def is_loud(message):
   # Strip out emojis because these are ok to be lowercase (and will not work as uppercase)
-  message = re.sub(emoji_regex, '', message).strip()
+  # message = re.sub(emoji_regex, '', message).strip()
   # Strip out tagging of specific people because future pokes are fun
   message = re.sub(tag_regex, '', message)
   # Strip out any punctuation


### PR DESCRIPTION
After some feedback about LOUDBOT, this change moves from a block list to an allow list for channel triggers, and disables emoji triggers for the time being (they are buggy)
Here are the allowed channels
```json
[
    "after-dinner-conversation",
    "badgeys-badges",
    "bahrats-bazaar",
    "dabo-table",
    "dr-crushers-hotbox",
    "megalomaniacal-computer-storage",
    "morns-nonstop-quiz",
    "poker-night",
    "robot-diagnostics",
    "seskas-catfishing-channel",
    "ten-forward",
    "temba-his-arms-wide"
]
```
