### PR TITLE
Set Global Reset Time For Scrapper

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.8.6
-appVersion: v1.8.6
+version: v1.8.7
+appVersion: v1.8.7

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -465,7 +465,6 @@ class ScrapButton(discord.ui.Button):
     last_scrap_time = db_get_scrap_last_timestamp(self.user_id)
     if last_scrap_time:
       to_zone = tz.tzlocal()
-      # past_time = datetime.fromtimestamp(last_scrap_time)
       last_scrap_time.replace(tzinfo=to_zone)
       current_time = datetime.now()
       if last_scrap_time.date() < current_time.date():
@@ -634,7 +633,6 @@ async def scrap(ctx:discord.ApplicationContext, first_badge:str, second_badge:st
     time_check_fail = True
 
     to_zone = tz.tzlocal()
-    # past_time = datetime.fromtimestamp(last_scrap_time)
     last_scrap_time.replace(tzinfo=to_zone)
     current_time = datetime.now()
     current_time.replace(tzinfo=to_zone)
@@ -648,7 +646,7 @@ async def scrap(ctx:discord.ApplicationContext, first_badge:str, second_badge:st
       humanized_time_left = humanize.precisedelta(midnight_tomorrow - current_time, suppress=["days"])
       await ctx.followup.send(embed=discord.Embed(
         title="Scrapper recharging, please wait.",
-        description=f"You may only perform one scrap every 24 hours.\n\nYou still must wait until Midnight Pacific ({humanized_time_left} left).",
+        description=f"Reset time at Midnight Pacific ({humanized_time_left} left).",
         color=discord.Color.red()
       ), ephemeral=True)
       return

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -1,3 +1,5 @@
+from dateutil import tz
+
 from common import *
 from cogs.trade import db_cancel_trade, get_offered_and_requested_badge_names
 from queries.wishlist import db_get_badge_locked_status_by_name
@@ -459,11 +461,17 @@ class ScrapButton(discord.ui.Button):
     user_badge_filenames = [b['badge_filename'] for b in user_badges]
     owned_user_badges = [b for b in self.badges_to_scrap if b['badge_filename'] in user_badge_filenames]
     # Ensure they haven't performed another scrap within the time period
-    time_check_fail = False
+    time_check_fail = True
     last_scrap_time = db_get_scrap_last_timestamp(self.user_id)
     if last_scrap_time:
-      time_difference = datetime.utcnow() - last_scrap_time
-      time_check_fail = time_difference.days == 0
+      to_zone = tz.tzlocal()
+      # past_time = datetime.fromtimestamp(last_scrap_time)
+      last_scrap_time.replace(tzinfo=to_zone)
+      current_time = datetime.now()
+      if last_scrap_time.date() < current_time.date():
+        time_check_fail = False
+    else:
+        time_check_fail = False
 
     if (len(owned_user_badges) != 3) or (time_check_fail):
       await interaction.response.edit_message(
@@ -623,12 +631,24 @@ async def scrap(ctx:discord.ApplicationContext, first_badge:str, second_badge:st
   # check that they're within the allowed time window
   last_scrap_time = db_get_scrap_last_timestamp(user_id)
   if last_scrap_time:
-    time_difference = datetime.utcnow() - last_scrap_time
-    if time_difference.days == 0:
-      humanized_time_left = humanize.precisedelta(timedelta(hours=24) - time_difference)
+    time_check_fail = True
+
+    to_zone = tz.tzlocal()
+    # past_time = datetime.fromtimestamp(last_scrap_time)
+    last_scrap_time.replace(tzinfo=to_zone)
+    current_time = datetime.now()
+    current_time.replace(tzinfo=to_zone)
+    if last_scrap_time.date() < current_time.date():
+      time_check_fail = False
+
+    if time_check_fail:
+      midnight_tomorrow = current_time.date() + timedelta(days=1)
+      midnight_tomorrow = datetime.combine(midnight_tomorrow, datetime.min.time())
+
+      humanized_time_left = humanize.precisedelta(midnight_tomorrow - current_time, suppress=["days"])
       await ctx.followup.send(embed=discord.Embed(
         title="Scrapper recharging, please wait.",
-        description=f"You may only perform one scrap every 24 hours.\n\nYou still have {humanized_time_left} left.",
+        description=f"You may only perform one scrap every 24 hours.\n\nYou still must wait until Midnight Pacific ({humanized_time_left} left).",
         color=discord.Color.red()
       ), ephemeral=True)
       return


### PR DESCRIPTION
Per request, set the reset time for everyone to Midnight Pacific so that folks can more easily know when they can do another scrap without having to run the command just to be denied.

![image](https://user-images.githubusercontent.com/1075211/185953094-9c1c4e93-40c2-4900-b80b-761213b5f605.png)
