### PR TITLE
Fix: Correct Wishlist Purger

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.8.8
-appVersion: v1.8.8
+version: v1.8.9
+appVersion: v1.8.9

--- a/utils/badge_utils.py
+++ b/utils/badge_utils.py
@@ -1142,6 +1142,7 @@ def db_purge_users_wishlist(user_discord_id: int):
     DELETE b_w FROM badge_wishlists AS b_w
       JOIN badges AS b
         ON b_w.badge_filename = b.badge_filename
+        AND b_w.user_discord_id = b.user_discord_id
       WHERE b.user_discord_id = %s
   '''
   vals = (user_discord_id,)


### PR DESCRIPTION
Wasn't joning on the user_id across the wishlist and badges tables, so every time someone received a new badges it was clearing that from _everyone else's_ wishlists as well. 🤦 