### PR TITLE
Feat: Add 'available' Option For locked/unlocked Badges In Badges Showcase

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.8.15
-appVersion: v1.8.15
+version: v1.8.16
+appVersion: v1.8.16

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -60,6 +60,21 @@ badge_group = bot.create_group("badges", "Badge Commands!")
   ]
 )
 @option(
+  name="available",
+  description="Show only Locked or Unlocked badges?",
+  required=False,
+  choices=[
+    discord.OptionChoice(
+      name="Unlocked",
+      value="unlocked"
+    ),
+    discord.OptionChoice(
+      name="Locked",
+      value="locked"
+    )
+  ]
+)
+@option(
   name="color",
   description="Which colorscheme would you like?",
   required=False,
@@ -68,16 +83,24 @@ badge_group = bot.create_group("badges", "Badge Commands!")
     for color_choice in ["Green", "Orange", "Purple", "Teal"]
   ]
 )
-async def showcase(ctx:discord.ApplicationContext, public:str, color:str):
+async def showcase(ctx:discord.ApplicationContext, public:str, available:str, color:str):
   public = (public == "yes")
   await ctx.defer(ephemeral=not public)
 
-  user_badges = db_get_user_badges(ctx.author.id)
+  if available is not None:
+    if available == 'unlocked':
+      title = f"{ctx.author.display_name.encode('ascii', errors='ignore').decode().strip()}'s Badge Collection - Unlocked"
+      user_badges = db_get_user_unlocked_badges(ctx.author.id)
+    else:
+      title = f"{ctx.author.display_name.encode('ascii', errors='ignore').decode().strip()}'s Badge Collection - Locked"
+      user_badges = db_get_user_locked_badges(ctx.author.id)
+  else:
+    title = f"{ctx.author.display_name.encode('ascii', errors='ignore').decode().strip()}'s Badge Collection"
+    user_badges = db_get_user_badges(ctx.author.id)
 
   # Set up text values for paginated pages
   total_badges_cnt = len(all_badge_info)
   user_badges_cnt = len(user_badges)
-  title = f"{ctx.author.display_name.encode('ascii', errors='ignore').decode().strip()}'s Badge Collection"
   collected = f"{user_badges_cnt} TOTAL ON THE USS HOOD"
   filename_prefix = f"badge_list_{ctx.author.id}-page-"
 

--- a/utils/badge_utils.py
+++ b/utils/badge_utils.py
@@ -731,6 +731,50 @@ def db_get_user_badges(user_discord_id:int):
   db.close()
   return badges
 
+def db_get_user_unlocked_badges(user_discord_id:int):
+  '''
+    get_unlocked_user_badges(user_discord_id)
+    user_discord_id[required]: int
+    returns a list of unlocked badges the user has
+  '''
+  db = getDB()
+  query = db.cursor(dictionary=True)
+  sql = '''
+    SELECT b_i.badge_name, b_i.badge_filename, b.locked FROM badges b
+      JOIN badge_info AS b_i
+        ON b.badge_filename = b_i.badge_filename
+        WHERE b.user_discord_id = %s AND b.locked = 0
+        ORDER BY b_i.badge_filename ASC
+  '''
+  vals = (user_discord_id,)
+  query.execute(sql, vals)
+  badges = query.fetchall()
+  query.close()
+  db.close()
+  return badges
+
+def db_get_user_locked_badges(user_discord_id:int):
+  '''
+    get_unlocked_user_badges(user_discord_id)
+    user_discord_id[required]: int
+    returns a list of unlocked badges the user has
+  '''
+  db = getDB()
+  query = db.cursor(dictionary=True)
+  sql = '''
+    SELECT b_i.badge_name, b_i.badge_filename, b.locked FROM badges b
+      JOIN badge_info AS b_i
+        ON b.badge_filename = b_i.badge_filename
+        WHERE b.user_discord_id = %s AND b.locked = 1
+        ORDER BY b_i.badge_filename ASC
+  '''
+  vals = (user_discord_id,)
+  query.execute(sql, vals)
+  badges = query.fetchall()
+  query.close()
+  db.close()
+  return badges
+
 def db_get_badge_count_for_user(user_id):
   db = getDB()
   query = db.cursor(dictionary=True)


### PR DESCRIPTION
Users now have an additional optional option in `/badges_showcase` to limit the display their badges to either locked or unlocked. Useful for trades so they can show others which ones they specifically have available for trading.

If the option is omitted, just does the regular showcase with all badges both locked and unlocked.

![image](https://user-images.githubusercontent.com/1075211/187523387-0e68c7df-f3b8-4bda-8a9b-b4f85517bd7d.png)

![image](https://user-images.githubusercontent.com/1075211/187523402-248e4fae-717d-4401-9823-8d9e6c5fce58.png)

![image](https://user-images.githubusercontent.com/1075211/187523415-7d8b3b5f-2e31-4193-822e-e5958e0edcdd.png)
