### PR TITLE
Tweak: Lock Wishlist Badges On Acquisition

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.9.2
-appVersion: v1.9.2
+version: v1.9.3
+appVersion: v1.9.3

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -2,7 +2,7 @@ from dateutil import tz
 
 from common import *
 from cogs.trade import db_cancel_trade, get_offered_and_requested_badge_names
-from queries.wishlist import db_get_badge_locked_status_by_name
+from queries.wishlist import db_get_badge_locked_status_by_name, db_lock_badge_by_filename
 from utils.badge_utils import *
 from utils.check_channel_access import access_check
 import queries.badge_completion as queries_badge_completion
@@ -909,6 +909,8 @@ async def gift_badge(ctx:discord.ApplicationContext, user:discord.User):
 
   # Remove any badges the user may have on their wishlist that they now possess
   db_purge_users_wishlist(user.id)
+  # Lock the badge if it was in their wishlist
+  db_lock_badge_by_filename(user.id, badge)
 
   channel = bot.get_channel(notification_channel_id)
   embed_title = "You got rewarded a badge!"
@@ -967,6 +969,8 @@ async def gift_specific_badge(ctx:discord.ApplicationContext, user:discord.User,
       give_user_specific_badge(user.id, badge_filename)
       # Remove any badges the user may have on their wishlist that they now possess
       db_purge_users_wishlist(user.id)
+      # Lock the badge if it was in their wishlist
+      db_lock_badge_by_filename(user.id, badge_filename)
 
   channel = bot.get_channel(notification_channel_id)
   embed_title = "You got rewarded a badge!"

--- a/handlers/xp.py
+++ b/handlers/xp.py
@@ -3,6 +3,7 @@ from time import sleep
 from numpy import block
 from common import *
 from commands.badges import give_user_badge, send_badge_reward_message
+from queries.wishlist import db_lock_badge_by_filename
 from utils.badge_utils import db_get_user_badges, db_purge_users_wishlist
 
 # rainbow of colors to cycle through for the logs
@@ -259,6 +260,9 @@ async def level_up_user(user:discord.User, level:int):
   badge = give_user_badge(user.id)
   # Remove any badges the user may have on their wishlist that they now possess
   db_purge_users_wishlist(user.id)
+  # Lock the badge if it was in their wishlist
+  db_lock_badge_by_filename(user.id, badge)
+
   await send_level_up_message(user, level, badge)
 
 def give_welcome_badge(user_id):


### PR DESCRIPTION
When a user receives a badge either via leveling up, trading, or gifting and that badge is on their wishlist, this now automatically locks the badge for them since it's assumed they're going to want to hang onto it.