### PR TITLE
Fix: Correct Wishlist Auto-Lock

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.9.4
-appVersion: v1.9.4
+version: v1.9.5
+appVersion: v1.9.5

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -2,11 +2,11 @@ from dateutil import tz
 
 from common import *
 from cogs.trade import db_cancel_trade, get_offered_and_requested_badge_names
-from queries.wishlist import db_get_badge_locked_status_by_name, db_get_wishlist_badge_matches, db_lock_badge_by_filename
-from utils.badge_utils import *
-from utils.check_channel_access import access_check
 import queries.badge_completion as queries_badge_completion
 from queries.badge_scrap import *
+from queries.wishlist import *
+from utils.badge_utils import *
+from utils.check_channel_access import access_check
 
 all_badge_info = db_get_all_badge_info()
 
@@ -941,10 +941,10 @@ async def gift_badge(ctx:discord.ApplicationContext, user:discord.User):
     ), ephemeral=True)
     return
 
+  # Lock the badge if it was in their wishlist
+  db_autolock_badges_by_filenames_if_in_wishlist(user.id, [badge])
   # Remove any badges the user may have on their wishlist that they now possess
   db_purge_users_wishlist(user.id)
-  # Lock the badge if it was in their wishlist
-  db_lock_badge_by_filename(user.id, badge)
 
   channel = bot.get_channel(notification_channel_id)
   embed_title = "You got rewarded a badge!"
@@ -1001,10 +1001,10 @@ async def gift_specific_badge(ctx:discord.ApplicationContext, user:discord.User,
     badge_filename = badge_info['badge_filename']
     if specific_badge not in [b['badge_name'] for b in user_badges]:
       give_user_specific_badge(user.id, badge_filename)
+      # Lock the badge if it was in their wishlist
+      db_autolock_badges_by_filenames_if_in_wishlist(user.id, [badge_filename])
       # Remove any badges the user may have on their wishlist that they now possess
       db_purge_users_wishlist(user.id)
-      # Lock the badge if it was in their wishlist
-      db_lock_badge_by_filename(user.id, badge_filename)
 
   channel = bot.get_channel(notification_channel_id)
   embed_title = "You got rewarded a badge!"

--- a/handlers/xp.py
+++ b/handlers/xp.py
@@ -3,7 +3,7 @@ from time import sleep
 from numpy import block
 from common import *
 from commands.badges import give_user_badge, send_badge_reward_message
-from queries.wishlist import db_lock_badge_by_filename
+from queries.wishlist import db_autolock_badges_by_filenames_if_in_wishlist
 from utils.badge_utils import db_get_user_badges, db_purge_users_wishlist
 
 # rainbow of colors to cycle through for the logs
@@ -258,10 +258,10 @@ async def level_up_user(user:discord.User, level:int):
   query.close()
   db.close()
   badge = give_user_badge(user.id)
+  # Lock the badge if it was in their wishlist
+  db_autolock_badges_by_filenames_if_in_wishlist(user.id, [badge])
   # Remove any badges the user may have on their wishlist that they now possess
   db_purge_users_wishlist(user.id)
-  # Lock the badge if it was in their wishlist
-  db_lock_badge_by_filename(user.id, badge)
 
   await send_level_up_message(user, level, badge)
 

--- a/queries/wishlist.py
+++ b/queries/wishlist.py
@@ -108,6 +108,25 @@ def db_clear_users_wishlist(user_discord_id):
 # |    |__(  <_> )  \___|    <   / /   |    |  /   |  \  |_(  <_> )  \___|    <
 # |_______ \____/ \___  >__|_ \ / /    |______/|___|  /____/\____/ \___  >__|_ \
 #         \/          \/     \/ \/                  \/                 \/     \/
+def db_autolock_badges_by_filenames_if_in_wishlist(user_discord_id, badge_filenames):
+  badges_values_list = []
+  for b in badge_filenames:
+    tuple = (user_discord_id, b)
+    badges_values_list.append(tuple)
+
+  db = getDB()
+  query = db.cursor()
+  sql = '''
+    UPDATE badges AS b
+      JOIN badge_wishlists AS b_w
+        ON b.user_discord_id = b_w.user_discord_id AND b.badge_filename = b_w.badge_filename
+        SET b.locked = 1 WHERE b.user_discord_id = %s AND b.badge_filename = %s
+  '''
+  query.executemany(sql, badges_values_list)
+  db.commit()
+  query.close()
+  db.close()
+
 def db_get_badge_locked_status_by_name(user_discord_id, badge_name):
   db = getDB()
   query = db.cursor(dictionary=True, buffered=True)


### PR DESCRIPTION
Well this is embarassing. Big ol' FAIL, wasn't actually checking the wishlists before performing the auto-lock. 🤦 

Corrects and added a little addition to the confirmation message sent to the requestor with a link to the confirmation message in-channel.