### PR TITLE
Fix: Badge Metadata Corrections #01

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.9.6
-appVersion: v1.9.6
+version: v1.9.7
+appVersion: v1.9.7

--- a/migrations/v1.9.7.sql
+++ b/migrations/v1.9.7.sql
@@ -1,0 +1,4 @@
+UPDATE badge_affiliation SET affiliation_name = "Las Mariposas" WHERE badge_filename = "Las_Mariposas_2020s.png" AND affiliation_name = "Las Maripsas";
+INSERT INTO badge_affiliation (badge_filename, affiliation_name) VALUES ("Bajor_Admission_Flag_A.png", "Bajor");
+INSERT INTO badge_affiliation (badge_filename, affiliation_name) VALUES ("Bajor_Admission_Flag_B.png", "Bajor");
+INSERT INTO badge_affiliation (badge_filename, affiliation_name) VALUES ("Vulcan_Science_Academy_(VSA).png", "Vulcan");


### PR DESCRIPTION
Seems like we'll need some of these occasionally if we spot metadata discrepencies.

This one is a migration to correct affiliations for a few Bajoran, Vulcan, and Mariposas Badges. Just gotta do the `db-migrate` after pullin.