### PR TITLE
Tweak: Use Higher React Threshold For High-Traffic Channels

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.9.8
-appVersion: v1.9.8
+version: v1.9.9
+appVersion: v1.9.9

--- a/configuration.json
+++ b/configuration.json
@@ -70,6 +70,11 @@
         "transporter-log",
         "polls"
       ],
+      "high_react_channels": [
+        "ten-forward",
+        "general-trek",
+        "temba-his-arms-wide"
+      ],
       "boards": {
         "the-argus-array": [],
         "bits-bits-bits": [

--- a/handlers/starboard.py
+++ b/handlers/starboard.py
@@ -2,11 +2,12 @@ import datetime
 from common import *
 from handlers.xp import increment_user_xp
 
-# TODO: 
+# TODO:
 # react to original post?
 # add more details to starboard post?
 
 react_threshold = 3 # how many reactions required
+high_react_threshold = 5
 argus_threshold = 10
 user_threshold = 3 # how many users required
 
@@ -34,21 +35,21 @@ async def handle_starboard_reactions(payload:discord.RawReactionActionEvent):
   # don't count users adding reacts to their own posts
   if message.author == reacting_user:
     return
-  
+
   # weird edge case where reaction can be a string (never seen it happen)
   if isinstance(reaction, str):
     logger.info(f"{Style.BRIGHT}{Fore.YELLOW}WHOA THE REACTION IS A STRING{Fore.RESET}{Style.RESET_ALL}")
     return
 
   # it might be safe to see if this is a starboard-worthy post now
-  # each starboard can have a set of words to match against, 
+  # each starboard can have a set of words to match against,
   # here we loop over each board and then each word that board has
   # the words will be in the emoji, not the message
   for board,match_reacts in board_dict.items():
-    
+
     if match_reacts:
       #logger.info(f"CHECKING {board}")
-       
+
       all_reacts = reactions
       message_reaction_people = set()
       total_reacts_for_this_match = 0
@@ -58,7 +59,7 @@ async def handle_starboard_reactions(payload:discord.RawReactionActionEvent):
         # loop over each reaction in the message
         for reaction in all_reacts:
           this_emoji = reaction.emoji
-          if hasattr(this_emoji, "name"):           
+          if hasattr(this_emoji, "name"):
             # if its a real emoji and has one of our words or matches exactly
             if re.search(r"([_]"+ re.escape(match)+")|("+ re.escape(match)+"[_])/igm", this_emoji.name.lower()) != None or this_emoji.name == match:
               # count the users who reacted with this one
@@ -67,17 +68,23 @@ async def handle_starboard_reactions(payload:discord.RawReactionActionEvent):
                 if user != message.author and user not in message_reaction_people:
                   total_reacts_for_this_match += 1
                   message_reaction_people.add(user) # and don't count them again!
-      
-      
+
+
       #total_people = len(message_reaction_people)
       #logger.info(f"{Fore.LIGHTWHITE_EX}{Style.BRIGHT}{board}: report for this post {message.content}...: reacts {total_reacts_for_this_match} -- total reacting people: {total_people}{Style.RESET_ALL}{Fore.RESET}")
 
+      # Some channels have a higher react threshold than others
+      adjusted_react_threshold = react_threshold
+      high_react_channel_ids = get_channel_ids_list(config["handlers"]["starboard"]["high_react_channels"])
+      if payload.channel_id in high_react_channel_ids:
+        adjusted_react_threshold = high_react_threshold
+
       # finally, if this match category has enough reactions and enough people, let's save it to the starboard channel!
-      if total_reacts_for_this_match >= react_threshold and len(message_reaction_people) >= user_threshold:
+      if total_reacts_for_this_match >= adjusted_react_threshold and len(message_reaction_people) >= user_threshold:
         if await get_starboard_post(message.id, board) is None: # checking again just in case (might be expensive)
           await add_starboard_post(message, board)
           return
-  
+
 
 async def add_starboard_post(message, board):
   global ALL_STARBOARD_POSTS
@@ -92,9 +99,9 @@ async def add_starboard_post(message, board):
   db.commit()
   query.close()
   db.close()
-  
+
   ALL_STARBOARD_POSTS.append(message.id)
-  
+
   board_channel = get_channel_id(board)
 
   # can't really re-embed tenor gifs quicky and they aren't REALLY starboard worthy imo
@@ -118,7 +125,7 @@ async def add_starboard_post(message, board):
   )
   if len(message.attachments) > 0:
     embed.set_image(url=message.attachments[0].url)
-  
+
   channel = bot.get_channel(board_channel)
   await channel.send(content=message.channel.mention, embed=embed)
   await message.add_reaction(random.choice(["🌟","⭐","✨"]))


### PR DESCRIPTION
With the number of active users we have now, we have a lot of messages being sent to the starboards in #ten-forward, #general-trek, and #temba-his-arms-wide.

Adding some code to bump up the number of reacts required for these channels from 3 to 5.