### PR TITLE
Fix: Decrease Wishlist Badges Per Page Due To Length Restriction

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.9.11
-appVersion: v1.9.11
+version: v1.9.12
+appVersion: v1.9.12

--- a/cogs/wishlist.py
+++ b/cogs/wishlist.py
@@ -126,7 +126,7 @@ class Wishlist(commands.Cog):
 
     if len(wishlist_badges):
       # Set up paginated results
-      max_badges_per_page = 50
+      max_badges_per_page = 30
       all_pages = [wishlist_badges[i:i + max_badges_per_page] for i in range(0, len(wishlist_badges), max_badges_per_page)]
       total_pages = len(all_pages)
 
@@ -217,7 +217,7 @@ class Wishlist(commands.Cog):
       for user_id in exact_matches_aggregate.keys():
         user = await bot.current_guild.fetch_member(user_id)
 
-        max_badges_per_page = 50
+        max_badges_per_page = 30
 
         # Pages for Badges Match Has
         has_badges = exact_matches_aggregate[user_id]['has']


### PR DESCRIPTION
Because I added the URL for the badge links we're hitting the 4096 character limit on large wishlist pages. Need to decrease the max badges per page from 50 to 30 to get them to fit now.