### PR TITLE
Feat: Badge Tags!

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.9.16
-appVersion: v1.9.16
+version: v1.10.0
+appVersion: v1.10.0

--- a/cogs/badge_tags.py
+++ b/cogs/badge_tags.py
@@ -1,0 +1,481 @@
+from common import *
+# from queries.badge_tags import *
+from utils.badge_utils import *
+from utils.check_channel_access import access_check
+
+all_badge_info = db_get_all_badge_info()
+
+#    _____          __                                     .__          __
+#   /  _  \  __ ___/  |_  ____   ____  ____   _____ ______ |  |   _____/  |_  ____
+#  /  /_\  \|  |  \   __\/  _ \_/ ___\/  _ \ /     \\____ \|  | _/ __ \   __\/ __ \
+# /    |    \  |  /|  | (  <_> )  \__(  <_> )  Y Y  \  |_> >  |_\  ___/|  | \  ___/
+# \____|__  /____/ |__|  \____/ \___  >____/|__|_|  /   __/|____/\___  >__|  \___  >
+#         \/                        \/            \/|__|             \/          \/
+def user_badges_autocomplete(ctx:discord.AutocompleteContext):
+  user_badges = [b['badge_name'] for b in db_get_user_badges(ctx.interaction.user.id)]
+  if len(user_badges) == 0:
+    user_badges = ["You don't have any badges yet!"]
+
+  return [result for result in user_badges if ctx.value.lower() in result.lower()]
+
+
+async def tags_autocomplete(ctx:discord.AutocompleteContext):
+  current_user_tags = [t['tag_name'] for t in db_get_user_badge_tags(ctx.interaction.user.id)]
+  current_user_tags.sort()
+
+  return [t for t in current_user_tags if ctx.value.lower() in t.lower()]
+
+# ____   ____.__
+# \   \ /   /|__| ______  _  ________
+#  \   Y   / |  |/ __ \ \/ \/ /  ___/
+#   \     /  |  \  ___/\     /\___ \
+#    \___/   |__|\___  >\/\_//____  >
+#                    \/           \/
+class TagSelector(discord.ui.Select):
+  def __init__(self, user_discord_id, badge_name):
+    user_badge_tags = db_get_user_badge_tags(user_discord_id)
+    associated_tags = db_get_associated_badge_tags(user_discord_id, badge_name)
+    associated_tag_names = [t['tag_name'] for t in associated_tags]
+    options = [
+      discord.SelectOption(
+        label=t['tag_name'],
+        value=str(t['id']),
+        default=t['tag_name'] in associated_tag_names
+      )
+      for t in user_badge_tags
+    ]
+
+    super().__init__(
+      placeholder="Select the tags you'd like to associate with this badge",
+      min_values=0,
+      max_values=len(user_badge_tags),
+      options=options,
+      row=1
+    )
+
+  async def callback(self, interaction:discord.Interaction):
+    await interaction.response.defer()
+    self.view.tag_ids = self.values
+
+
+class TagButton(discord.ui.Button):
+  def __init__(self, cog, user_discord_id, badge_name):
+    self.cog = cog
+    self.user_discord_id = user_discord_id
+    self.badge_name = badge_name
+    super().__init__(
+      label="           Tag Badge           ",
+      style=discord.ButtonStyle.primary,
+      row=2
+    )
+
+  async def callback(self, interaction:discord.Interaction):
+    associated_tags = db_get_associated_badge_tags(self.user_discord_id, self.badge_name)
+    logger.info(associated_tags)
+    tag_ids_to_delete = [t['id'] for t in associated_tags if t['id'] not in self.view.tag_ids]
+    logger.info(tag_ids_to_delete)
+    db_delete_badge_tags_associations(tag_ids_to_delete)
+    if len(self.view.tag_ids):
+      db_create_badge_tags_associations(self.user_discord_id, self.badge_name, self.view.tag_ids)
+
+    new_associated_tags = db_get_associated_badge_tags(self.user_discord_id, self.badge_name)
+    associated_tag_names = [t['tag_name'] for t in new_associated_tags]
+
+    if len(associated_tag_names):
+      description = f"**{self.badge_name}** is now tagged with:" + "\n\n" + "\n".join(associated_tag_names)
+    else:
+      description = f"**{self.badge_name}** no longer has any tags associated!"
+
+    await interaction.response.edit_message(
+      embed=discord.Embed(
+        title="Tags Updated",
+        description=description,
+        color=discord.Color.green()
+      ),
+      view=None,
+      files=[]
+    )
+
+
+class TagBadgeView(discord.ui.View):
+  def __init__(self, cog, user_discord_id, badge_name):
+    super().__init__()
+
+    self.tag_ids = []
+    self.add_item(TagSelector(user_discord_id, badge_name))
+    self.add_item(TagButton(cog, user_discord_id, badge_name))
+
+# __________             .___           ___________                    _________
+# \______   \_____     __| _/ ____   ___\__    ___/____     ____  _____\_   ___ \  ____   ____
+#  |    |  _/\__  \   / __ | / ___\_/ __ \|    |  \__  \   / ___\/  ___/    \  \/ /  _ \ / ___\
+#  |    |   \ / __ \_/ /_/ |/ /_/  >  ___/|    |   / __ \_/ /_/  >___ \\     \___(  <_> ) /_/  >
+#  |______  /(____  /\____ |\___  / \___  >____|  (____  /\___  /____  >\______  /\____/\___  /
+#         \/      \/      \/_____/      \/             \//_____/     \/        \/      /_____/
+class BadgeTags(commands.Cog):
+  def __init__(self, bot):
+    self.bot = bot
+    self.max_tags = 25 # We can only have 25 items in a Discord select component
+
+  tags_group = discord.SlashCommandGroup("tags", "Badge Tags Commands!")
+
+  @tags_group.command(
+    name="create",
+    description="Create a new badge tag. (NOTE: You can have a max of 25 tags)"
+  )
+  @option(
+    name="tag",
+    description="Name of the tag to create",
+    required=True,
+    min_length=1,
+    max_length=24
+  )
+  async def create(self, ctx:discord.ApplicationContext, tag:str):
+    await ctx.defer(ephemeral=True)
+
+    tag = tag.strip()
+    if len(tag) == 0:
+      await ctx.followup.send(
+        embed=discord.Embed(
+          title="You Must Enter A Tag!",
+          description=f"Tag name cannot be empty!",
+          color=discord.Color.red()
+        ),
+        ephemeral=True
+      )
+      return
+
+    current_user_tags = db_get_user_badge_tags(ctx.author.id)
+    current_user_tag_names = [t['tag_name'] for t in current_user_tags]
+
+    if tag in current_user_tag_names:
+      await ctx.followup.send(
+        embed=discord.Embed(
+          title="This Tag Already Exists",
+          description=f"You've already created **{tag}**!\n\nYou can associate your badges with this tag via `/tags tag`!",
+          color=discord.Color.red()
+        ),
+        ephemeral=True
+      )
+      return
+
+    if len(current_user_tags) >= self.max_tags:
+      await ctx.followup.send(
+        embed=discord.Embed(
+          title="Maximum Tags Allowed Reached",
+          description=f"You've reached the maximum number of tags allowed ({self.max_tags})!\n\nYou can remove a tag if desired via `/tags delete`!",
+          color=discord.Color.red()
+        ),
+        ephemeral=True
+      )
+      return
+
+    # If checks pass, go ahead and create the new tag for the user
+    db_create_user_tag(ctx.author.id, tag)
+    await ctx.followup.send(
+      embed=discord.Embed(
+        title="Tag Created Successfully!",
+        description=f"You've created a new tag: **{tag}**!\n\nYou can associate your badges with this tag now via `/tags tag`",
+        color=discord.Color.green()
+      ),
+      ephemeral=True
+    )
+    return
+
+  @tags_group.command(
+    name="delete",
+    description="Delete an existing badge tag"
+  )
+  @option(
+    name="tag",
+    description="Name of the tag to delete",
+    required=True,
+    autocomplete=tags_autocomplete
+  )
+  async def create(self, ctx:discord.ApplicationContext, tag:str):
+    await ctx.defer(ephemeral=True)
+
+    tag = tag.strip()
+    if len(tag) == 0:
+      await ctx.followup.send(
+        embed=discord.Embed(
+          title="You Must Enter A Tag!",
+          description=f"Tag name cannot be empty!",
+          color=discord.Color.red()
+        ),
+        ephemeral=True
+      )
+      return
+
+    current_user_tags = db_get_user_badge_tags(ctx.author.id)
+    current_user_tag_names = [t['tag_name'] for t in current_user_tags]
+
+    if tag not in current_user_tag_names:
+      await ctx.followup.send(
+        embed=discord.Embed(
+          title="This Tag Does Not Exist",
+          description=f"**{tag}** is not a tag you have created!\n\nYou can create a new tag via `/tags create`!",
+          color=discord.Color.red()
+        ),
+        ephemeral=True
+      )
+      return
+
+    # If checks pass, go ahead and delete the tag for the user
+    db_delete_user_tag(ctx.author.id, tag)
+    await ctx.followup.send(
+      embed=discord.Embed(
+        title="Tag Deleted Successfully!",
+        description=f"You've deleted the tag: **{tag}**!\n\nNote that any badges that were previously associated with the tag have been disassociated as well.",
+        color=discord.Color.green()
+      ),
+      ephemeral=True
+    )
+    return
+
+  @tags_group.command(
+    name="tag_badge",
+    description="Tag one of your badges!"
+  )
+  @option(
+    name="badge",
+    description="Name of the badge to tag",
+    required=True,
+    autocomplete=user_badges_autocomplete
+  )
+  async def tag_badge(self, ctx:discord.ApplicationContext, badge:str):
+    await ctx.defer(ephemeral=True)
+
+    user_badges = db_get_user_badges(ctx.author.id)
+    user_badge_names = [b['badge_name'] for b in user_badges]
+    if badge not in user_badge_names:
+      await ctx.followup.send(
+        embed=discord.Embed(
+          title="Badge Not Present In Inventory",
+          description=f"You don't own this badge!",
+          color=discord.Color.red()
+        ),
+        ephemeral=True
+      )
+      return
+
+    badge_info = db_get_badge_info_by_name(badge)
+
+    view = TagBadgeView(self, ctx.author.id, badge)
+    embed = discord.Embed(
+      title=badge,
+      description="Select the tags below you'd like to associate with this badge.",
+      color=discord.Color.dark_purple()
+    )
+    badge_image = discord.File(fp=f"./images/badges/{badge_info['badge_filename']}", filename=badge_info['badge_filename'])
+    embed.set_image(url=f"attachment://{badge_info['badge_filename']}")
+
+    await ctx.followup.send(embed=embed, file=badge_image, view=view, ephemeral=True)
+
+  @tags_group.command(
+    name="showcase",
+    description="Display a showcase of tagged badges"
+  )
+  @option(
+    name="public",
+    description="Show to public?",
+    required=True,
+    choices=[
+      discord.OptionChoice(
+        name="No",
+        value="no"
+      ),
+      discord.OptionChoice(
+        name="Yes",
+        value="yes"
+      )
+    ]
+  )
+  @option(
+    name="tag",
+    description="Name of the tag to showcase",
+    required=True,
+    autocomplete=tags_autocomplete
+  )
+  async def showcase(self, ctx:discord.ApplicationContext, public:str, tag:str):
+    public = (public == "yes")
+    await ctx.defer(ephemeral=not public)
+
+    title = f"{ctx.author.display_name.encode('ascii', errors='ignore').decode().strip()}'s Tagged Badges - {tag}"
+    tagged_badges = db_get_user_tagged_badges(ctx.author.id, tag)
+
+    logger.info(tagged_badges)
+
+    # Set up text values for paginated pages
+    total_badges_cnt = len(all_badge_info)
+    tagged_badges_cnt = len(tagged_badges)
+    collected = f"{tagged_badges_cnt} TAGGED ON THE USS HOOD"
+    filename_prefix = f"badge_list_tagged_{ctx.author.id}-page-"
+
+    badge_images = await generate_paginated_badge_images(ctx.author, 'showcase', tagged_badges, total_badges_cnt, title, collected, filename_prefix)
+
+    embed = discord.Embed(
+      title=f"Tagged Badges",
+      description=f'{ctx.author.mention} has tagged {tagged_badges_cnt} "{tag}" badges!',
+      color=discord.Color.blurple()
+    )
+
+    # If we're doing a public display, use the images directly
+    # Otherwise private displays can use the paginator
+    if not public:
+      buttons = [
+        pages.PaginatorButton("prev", label="   ⬅   ", style=discord.ButtonStyle.primary, disabled=bool(user_badges_cnt <= 30), row=1),
+        pages.PaginatorButton(
+          "page_indicator", style=discord.ButtonStyle.gray, disabled=True, row=1
+        ),
+        pages.PaginatorButton("next", label="   ➡   ", style=discord.ButtonStyle.primary, disabled=bool(user_badges_cnt <= 30), row=1),
+      ]
+
+      pages_list = [
+        pages.Page(files=[image], embeds=[embed])
+        for image in badge_images
+      ]
+      paginator = pages.Paginator(
+          pages=pages_list,
+          show_disabled=True,
+          show_indicator=True,
+          use_default_buttons=False,
+          custom_buttons=buttons,
+          loop_pages=True
+      )
+      await paginator.respond(ctx.interaction, ephemeral=True)
+    else:
+      # We can only attach up to 10 files per message, so if it's public send them in chunks
+      file_chunks = [badge_images[i:i + 10] for i in range(0, len(badge_images), 10)]
+      for chunk_index, chunk in enumerate(file_chunks):
+        # Only post the embed on the last chunk
+        if chunk_index + 1 == len(file_chunks):
+          await ctx.followup.send(embed=embed, files=chunk, ephemeral=False)
+        else:
+          await ctx.followup.send(files=chunk, ephemeral=False)
+
+# ________                      .__
+# \_____  \  __ __   ___________|__| ____   ______
+#  /  / \  \|  |  \_/ __ \_  __ \  |/ __ \ /  ___/
+# /   \_/.  \  |  /\  ___/|  | \/  \  ___/ \___ \
+# \_____\ \_/____/  \___  >__|  |__|\___  >____  >
+#        \__>           \/              \/     \/
+
+# TODO: Move this into queries.badge_tags
+
+def db_get_user_badge_tags(user_discord_id) -> list:
+  """
+  returns a list of the users's current custom badge tags
+  """
+  with getDB() as db:
+    query = db.cursor(dictionary=True)
+    sql = "SELECT * FROM badge_tags WHERE user_discord_id = %s ORDER BY tag_name ASC"
+    vals = (user_discord_id,)
+    query.execute(sql, vals)
+    results = query.fetchall()
+  return results
+
+
+def db_create_user_tag(user_discord_id, tag) -> None:
+  """
+  creates a new tag for the user in question
+  """
+  with getDB() as db:
+    query = db.cursor()
+    sql = "INSERT INTO badge_tags (user_discord_id, tag_name) VALUES (%s, %s)"
+    vals = (user_discord_id, tag)
+    query.execute(sql, vals)
+    db.commit()
+
+
+def db_delete_user_tag(user_discord_id, tag) -> None:
+  """
+  delete a tag for the user in question
+  """
+  with getDB() as db:
+    query = db.cursor()
+    sql = "DELETE FROM badge_tags WHERE user_discord_id = %s AND tag_name = %s"
+    vals = (user_discord_id, tag)
+    query.execute(sql, vals)
+    db.commit()
+
+
+def db_get_associated_badge_tags(user_discord_id, badge_name) -> list:
+  """
+  returns a list of the current tags the user has associated with a given badge
+  """
+  with getDB() as db:
+    query = db.cursor(dictionary=True)
+    sql = '''
+      SELECT b_t.* FROM badge_tags AS b_t
+        JOIN badge_tags_associations AS t_a ON b_t.id = t_a.badge_tags_id
+        JOIN badges AS b ON t_a.badges_id = b.id
+        JOIN badge_info AS b_i ON b_i.badge_filename = b.badge_filename
+          WHERE b_i.badge_name = %s AND b_t.user_discord_id = %s
+    '''
+    vals = (badge_name, user_discord_id)
+    query.execute(sql, vals)
+    results = query.fetchall()
+  return results
+
+
+def db_create_badge_tags_associations(user_discord_id, badge_name, tag_ids):
+  """
+  associates a list of tags with a user's specific badge
+  """
+  tags_values_list = []
+  for id in tag_ids:
+    tuple = (id, badge_name, user_discord_id)
+    tags_values_list.append(tuple)
+
+  with getDB() as db:
+    query = db.cursor(dictionary=True)
+    sql = '''
+      INSERT INTO badge_tags_associations (badges_id, badge_tags_id)
+        SELECT b.id, %s
+          FROM badges AS b
+          JOIN badge_info AS b_i ON b_i.badge_filename = b.badge_filename
+            WHERE b_i.badge_name = %s AND b.user_discord_id = %s
+    '''
+    query.executemany(sql, tags_values_list)
+    db.commit()
+
+def db_delete_badge_tags_associations(tag_ids):
+  """
+  deletes a list of tags from association with a user's specific badge
+  """
+  tags_values_list = []
+  for id in tag_ids:
+    tuple = (id,)
+    tags_values_list.append(tuple)
+
+  with getDB() as db:
+    query = db.cursor(dictionary=True)
+    sql = '''
+      DELETE FROM badge_tags_associations WHERE badge_tags_id = %s
+    '''
+    query.executemany(sql, tags_values_list)
+    db.commit()
+
+def db_get_user_tagged_badges(user_discord_id, tag):
+  '''
+    get_user_badges(user_discord_id)
+    user_discord_id[required]: int
+    returns a list of badges the user has
+  '''
+  with getDB() as db:
+    query = db.cursor(dictionary=True)
+    sql = '''
+      SELECT b_i.badge_name, b_i.badge_filename, b.locked, b_i.special FROM badges b
+        JOIN badge_info AS b_i
+          ON b.badge_filename = b_i.badge_filename
+        JOIN badge_tags_associations AS t_a
+          ON t_a.badges_id = b.id
+        JOIN badge_tags AS b_t
+          ON b.user_discord_id = b_t.user_discord_id AND t_a.badge_tags_id = b_t.id
+        WHERE b.user_discord_id = %s AND b_t.tag_name = %s
+          ORDER BY b_i.badge_filename ASC
+    '''
+    vals = (user_discord_id, tag)
+    query.execute(sql, vals)
+    badges = query.fetchall()
+  return badges

--- a/cogs/badge_tags.py
+++ b/cogs/badge_tags.py
@@ -73,7 +73,8 @@ class TagButton(discord.ui.Button):
   async def callback(self, interaction:discord.Interaction):
     associated_tags = db_get_associated_badge_tags(self.user_discord_id, self.badge_name)
     tag_ids_to_delete = [t['id'] for t in associated_tags if t['id'] not in self.view.tag_ids]
-    db_delete_badge_tags_associations(tag_ids_to_delete)
+    badge_info = db_get_badge_info_by_name(self.badge_name)
+    db_delete_badge_tags_associations(tag_ids_to_delete, badge_info['badge_filename'])
     if len(self.view.tag_ids):
       db_create_badge_tags_associations(self.user_discord_id, self.badge_name, self.view.tag_ids)
 

--- a/cogs/badge_tags.py
+++ b/cogs/badge_tags.py
@@ -151,7 +151,7 @@ class BadgeTags(commands.Cog):
       await ctx.followup.send(
         embed=discord.Embed(
           title="This Tag Already Exists",
-          description=f"You've already created **{tag}**!\n\nYou can associate your badges with this tag via `/tags tag`!",
+          description=f"You've already created **{tag}**!\n\nYou can associate your badges with this tag via `/tags tag_badge`!",
           color=discord.Color.red()
         ),
         ephemeral=True
@@ -174,7 +174,7 @@ class BadgeTags(commands.Cog):
     await ctx.followup.send(
       embed=discord.Embed(
         title="Tag Created Successfully!",
-        description=f"You've created a new tag: **{tag}**!\n\nYou can associate your badges with this tag now via `/tags tag`",
+        description=f"You've created a new tag: **{tag}**!\n\nYou can associate your badges with this tag now via `/tags tag_badge`",
         color=discord.Color.green()
       ),
       ephemeral=True
@@ -263,7 +263,6 @@ class BadgeTags(commands.Cog):
     view = TagBadgeView(self, ctx.author.id, badge)
     embed = discord.Embed(
       title=badge,
-      description="Select the tags below you'd like to associate with this badge.",
       color=discord.Color.dark_purple()
     )
     badge_image = discord.File(fp=f"./images/badges/{badge_info['badge_filename']}", filename=badge_info['badge_filename'])

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -783,7 +783,7 @@ class Trade(commands.Cog):
       value=request
     )
     initiated_embed.set_footer(text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}")
-    await ctx.followup.send(embed=initiated_embed)
+    await ctx.followup.send(embed=initiated_embed, ephemeral=True)
 
     if offer:
       badge_info = db_get_badge_info_by_name(offer)
@@ -858,7 +858,6 @@ class Trade(commands.Cog):
         view=None,
         attachments=[]
       )
-
 
       # Alert the requestee that the trade has been canceled if the trade was active
       user = get_user(requestee.id)

--- a/configuration.json
+++ b/configuration.json
@@ -568,7 +568,8 @@
     },
     "randomep": {
       "channels": [
-        "after-dinner-conversation"
+        "after-dinner-conversation",
+        "general-trek"
       ],
       "enabled": true,
       "data": null,
@@ -690,6 +691,22 @@
       ],
       "enabled": true,
       "data": null,
+      "parameters": []
+    },
+    "tags tag": {
+      "channels": [
+        "badgeys-badges",
+        "bahrats-bazaar"
+      ],
+      "enabled": true,
+      "parameters": []
+    },
+    "tags showcase": {
+      "channels": [
+        "badgeys-badges",
+        "bahrats-bazaar"
+      ],
+      "enabled": true,
       "parameters": []
     },
     "testslots": {

--- a/data/seed-db.sql
+++ b/data/seed-db.sql
@@ -165,14 +165,14 @@ CREATE TABLE IF NOT EXISTS `badge_scraps` (
   CONSTRAINT `badge_scraps_fk_badge_filename` FOREIGN KEY (`badge_filename`) REFERENCES `badge_info` (`badge_filename`)
 );
 CREATE TABLE IF NOT EXISTS `badge_scrapped` (
-    `id` int NOT NULL AUTO_INCREMENT,
-    `scrap_id` int(11) NOT NULL,
-    `badge_filename` varchar(128) NOT NULL,
-    `time_created` timestamp NOT NULL DEFAULT current_timestamp(),
-    PRIMARY KEY (`id`),
-    KEY `badge_filename` (`badge_filename`),
-    FOREIGN KEY (`scrap_id`) REFERENCES `badge_scraps` (`id`),
-    FOREIGN KEY (`badge_filename`) REFERENCES `badge_info` (`badge_filename`)
+  `id` int NOT NULL AUTO_INCREMENT,
+  `scrap_id` int(11) NOT NULL,
+  `badge_filename` varchar(128) NOT NULL,
+  `time_created` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`),
+  KEY `badge_filename` (`badge_filename`),
+  FOREIGN KEY (`scrap_id`) REFERENCES `badge_scraps` (`id`),
+  FOREIGN KEY (`badge_filename`) REFERENCES `badge_info` (`badge_filename`)
 );
 CREATE TABLE IF NOT EXISTS reactions (
   id int(11) NOT NULL AUTO_INCREMENT,
@@ -226,4 +226,20 @@ CREATE TABLE IF NOT EXISTS badge_wishlists (
   PRIMARY KEY (`id`),
   KEY `badge_filename` (`badge_filename`),
   CONSTRAINT `badge_wishlists_fk_badge_filename` FOREIGN KEY (`badge_filename`) REFERENCES `badge_info` (`badge_filename`)
+);
+CREATE TABLE IF NOT EXISTS badge_tags (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_discord_id` varchar(128) NOT NULL,
+  `tag_name` varchar(24) NOT NULL,
+  PRIMARY KEY (`id`)
+);
+CREATE TABLE IF NOT EXISTS badge_tags_associations (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `badges_id` int(11) NOT NULL,
+  `badge_tags_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `badges_id` (`badges_id`),
+  CONSTRAINT `badges_tags_associations_fk_badges_id` FOREIGN KEY (`badges_id`) REFERENCES `badges` (`id`) ON DELETE CASCADE,
+  KEY `badge_tags_id` (`badge_tags_id`),
+  CONSTRAINT `badge_tags_associations_fk_badge_tags_id` FOREIGN KEY (`badge_tags_id`) REFERENCES `badge_tags` (`id`) ON DELETE CASCADE
 );

--- a/handlers/starboard.py
+++ b/handlers/starboard.py
@@ -92,8 +92,9 @@ async def add_starboard_post(message, board) -> None:
   
   await increment_user_xp(message.author, 2, "starboard_post", message.channel) # give em that sweet sweet xp first
   ALL_STARBOARD_POSTS.append(message.id) # add post ID to in-memory list
-  board_channel_id = get_channel_id(board) 
-  insert_starboard_post(message.id, message.author.id, board_channel_id) # add post to DB
+  board_channel_id = get_channel_id(board)
+  channel = bot.get_channel(board_channel_id) # where it will be posted
+  insert_starboard_post(message.id, message.author.id, board) # add post to DB
   
   provider_name, message_str, embed_image_url, embed_title, embed_desc, embed_thumb = ["" for i in range(6)] # initialize all the blank strings
   jumplink = f"[View original message]({message.jump_url}) from {message.channel.name}"
@@ -180,7 +181,7 @@ async def add_starboard_post(message, board) -> None:
   
   star_embed.description += f"\n{get_emoji('combadge')}\n\n{jumplink}"
 
-  channel = bot.get_channel(board_channel_id)
+  
   await channel.send(content=message_str, embed=star_embed) # send main embed
   await message.add_reaction(random.choice(["🌟","⭐","✨"])) # react to original post
   logger.info(f"{Fore.RED}AGIMUS{Fore.RESET} has added {message.author.display_name}'s post to {Style.BRIGHT}{board}{Style.RESET_ALL}!")

--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ from commands.agimus import agimus
 from commands.computer import computer
 
 # Cogs
+from cogs.badge_tags import BadgeTags
 from cogs.chaoszork import ChaosZork
 from cogs.poker import Poker
 from cogs.profile import Profile
@@ -50,6 +51,7 @@ from cogs.react_roles import ReactRoles
 from cogs.backups import Backups
 from cogs.wishlist import Wishlist
 from cogs.wordcloud import Wordcloud
+bot.add_cog(BadgeTags(bot))
 bot.add_cog(ChaosZork(bot))
 bot.add_cog(Poker(bot))
 bot.add_cog(Profile(bot))

--- a/queries/badge_tags.py
+++ b/queries/badge_tags.py
@@ -1,0 +1,126 @@
+from common import *
+
+# ________                      .__
+# \_____  \  __ __   ___________|__| ____   ______
+#  /  / \  \|  |  \_/ __ \_  __ \  |/ __ \ /  ___/
+# /   \_/.  \  |  /\  ___/|  | \/  \  ___/ \___ \
+# \_____\ \_/____/  \___  >__|  |__|\___  >____  >
+#        \__>           \/              \/     \/
+
+def db_get_user_badge_tags(user_discord_id) -> list:
+  """
+  returns a list of the users's current custom badge tags
+  """
+  with getDB() as db:
+    query = db.cursor(dictionary=True)
+    sql = "SELECT * FROM badge_tags WHERE user_discord_id = %s ORDER BY tag_name ASC"
+    vals = (user_discord_id,)
+    query.execute(sql, vals)
+    results = query.fetchall()
+  return results
+
+
+def db_create_user_tag(user_discord_id, tag) -> None:
+  """
+  creates a new tag for the user in question
+  """
+  with getDB() as db:
+    query = db.cursor()
+    sql = "INSERT INTO badge_tags (user_discord_id, tag_name) VALUES (%s, %s)"
+    vals = (user_discord_id, tag)
+    query.execute(sql, vals)
+    db.commit()
+
+
+def db_delete_user_tag(user_discord_id, tag) -> None:
+  """
+  delete a tag for the user in question
+  """
+  with getDB() as db:
+    query = db.cursor()
+    sql = "DELETE FROM badge_tags WHERE user_discord_id = %s AND tag_name = %s"
+    vals = (user_discord_id, tag)
+    query.execute(sql, vals)
+    db.commit()
+
+
+def db_get_associated_badge_tags(user_discord_id, badge_name) -> list:
+  """
+  returns a list of the current tags the user has associated with a given badge
+  """
+  with getDB() as db:
+    query = db.cursor(dictionary=True)
+    sql = '''
+      SELECT b_t.* FROM badge_tags AS b_t
+        JOIN badge_tags_associations AS t_a ON b_t.id = t_a.badge_tags_id
+        JOIN badges AS b ON t_a.badges_id = b.id
+        JOIN badge_info AS b_i ON b_i.badge_filename = b.badge_filename
+          WHERE b_i.badge_name = %s AND b_t.user_discord_id = %s
+    '''
+    vals = (badge_name, user_discord_id)
+    query.execute(sql, vals)
+    results = query.fetchall()
+  return results
+
+
+def db_create_badge_tags_associations(user_discord_id, badge_name, tag_ids):
+  """
+  associates a list of tags with a user's specific badge
+  """
+  tags_values_list = []
+  for id in tag_ids:
+    tuple = (id, badge_name, user_discord_id)
+    tags_values_list.append(tuple)
+
+  with getDB() as db:
+    query = db.cursor(dictionary=True)
+    sql = '''
+      INSERT INTO badge_tags_associations (badges_id, badge_tags_id)
+        SELECT b.id, %s
+          FROM badges AS b
+          JOIN badge_info AS b_i ON b_i.badge_filename = b.badge_filename
+            WHERE b_i.badge_name = %s AND b.user_discord_id = %s
+    '''
+    query.executemany(sql, tags_values_list)
+    db.commit()
+
+def db_delete_badge_tags_associations(tag_ids):
+  """
+  deletes a list of tags from association with a user's specific badge
+  """
+  tags_values_list = []
+  for id in tag_ids:
+    tuple = (id,)
+    tags_values_list.append(tuple)
+
+  with getDB() as db:
+    query = db.cursor(dictionary=True)
+    sql = '''
+      DELETE FROM badge_tags_associations WHERE badge_tags_id = %s
+    '''
+    query.executemany(sql, tags_values_list)
+    db.commit()
+
+def db_get_user_tagged_badges(user_discord_id, tag):
+  '''
+    get_user_badges(user_discord_id)
+    user_discord_id[required]: int
+    returns a list of badges the user has
+  '''
+  with getDB() as db:
+    query = db.cursor(dictionary=True)
+    sql = '''
+      SELECT b_i.badge_name, b_i.badge_filename, b.locked, b_i.special FROM badges b
+        JOIN badge_info AS b_i
+          ON b.badge_filename = b_i.badge_filename
+        JOIN badge_tags_associations AS t_a
+          ON t_a.badges_id = b.id
+        JOIN badge_tags AS b_t
+          ON b.user_discord_id = b_t.user_discord_id AND t_a.badge_tags_id = b_t.id
+        WHERE b.user_discord_id = %s AND b_t.tag_name = %s
+          ORDER BY b_i.badge_filename ASC
+    '''
+    vals = (user_discord_id, tag)
+    query.execute(sql, vals)
+    badges = query.fetchall()
+  return badges

--- a/queries/badge_tags.py
+++ b/queries/badge_tags.py
@@ -84,19 +84,21 @@ def db_create_badge_tags_associations(user_discord_id, badge_name, tag_ids):
     query.executemany(sql, tags_values_list)
     db.commit()
 
-def db_delete_badge_tags_associations(tag_ids):
+def db_delete_badge_tags_associations(tag_ids, badge_filename):
   """
   deletes a list of tags from association with a user's specific badge
   """
   tags_values_list = []
   for id in tag_ids:
-    tuple = (id,)
+    tuple = (id, badge_filename)
     tags_values_list.append(tuple)
 
   with getDB() as db:
     query = db.cursor(dictionary=True)
     sql = '''
-      DELETE FROM badge_tags_associations WHERE badge_tags_id = %s
+      DELETE t_a FROM badge_tags_associations AS t_a
+        JOIN badges AS b ON b.id = t_a.badges_id
+          WHERE t_a.badge_tags_id = %s AND b.badge_filename = %s
     '''
     query.executemany(sql, tags_values_list)
     db.commit()


### PR DESCRIPTION
Users can now tag their badges using the `/tags` commands!

![image](https://user-images.githubusercontent.com/1075211/188953517-0ba0ca0f-9dbf-4b29-87f3-bfb04978d82a.png)

![image](https://user-images.githubusercontent.com/1075211/188953676-574e4cd4-1a1a-43fe-9731-e2ff08da7174.png)

Bumped minor version to `v1.10.0` because we're adding new tables, but no migration needed because `seed-db.sql` should take care of it on bot bootup.