### PR TITLE
FIx: Check User's Inventory for Wishlist Addition/Removal Via React

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.10.2
-appVersion: v1.10.2
+version: v1.10.4
+appVersion: v1.10.4


### PR DESCRIPTION
Had a bug where users were able to add things to their wishlist that they already posessed via the ✅ react. This prevents that from occuring.

Additionally we now send a DM to the user on successful wishlist addition/removal to confirm that this is their desired action.