### PR TITLE
Feat: Shimoda Nominator

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.10.4
-appVersion: v1.10.4
+version: v1.10.5
+appVersion: v1.10.5

--- a/commands/shimoda.py
+++ b/commands/shimoda.py
@@ -1,0 +1,56 @@
+from common import *
+
+class ShimodaModal(discord.ui.Modal):
+  def __init__(self, *args, **kwargs) -> None:
+    super().__init__(
+      discord.ui.InputText(
+          label="Episode",
+          placeholder="Episode Title",
+      ),
+      discord.ui.InputText(
+          label="Character",
+          placeholder="Which Character?",
+      ),
+      discord.ui.InputText(
+        label="Reason",
+        style=discord.InputTextStyle.long,
+      ),
+      *args,
+      **kwargs,
+    )
+
+  async def callback(self, interaction:discord.Interaction):
+      pollster_embed = discord.Embed(
+        title="New Shimoda Nomination",
+        description=f"{interaction.user.mention} has nominated a new Drunk Shimoda!",
+        fields=[
+          discord.EmbedField(name="Episode", value=self.children[0].value, inline=True),
+          discord.EmbedField(name="Character", value=self.children[1].value, inline=True),
+          discord.EmbedField(name="Reason", value=self.children[2].value, inline=False)
+        ],
+        color=discord.Color.random()
+      )
+      roles = await bot.current_guild.fetch_roles()
+      pollster_role = None
+      for r in roles:
+        if r.name == config['roles']['shimoda_pollsters']:
+          pollster_role = r
+
+      recipients = pollster_role.members
+      for recipient in recipients:
+        await recipient.send(embed=pollster_embed)
+
+      await interaction.response.send_message(embed=discord.Embed(
+        title="Drunk Shimoda Nomination Successfully Sent!",
+        color=discord.Color.green()
+      ), ephemeral=True)
+
+
+
+@bot.slash_command(
+  name="shimoda",
+  description="Nominate a character for an episode's Drunk Shimoda poll!"
+)
+async def shimoda(ctx:discord.ApplicationContext):
+  modal = ShimodaModal(title="Drunk Shimoda Nomination")
+  await ctx.send_modal(modal)

--- a/configuration.json
+++ b/configuration.json
@@ -824,8 +824,10 @@
   "guild_ids": [
     689512841887481875
   ],
+  "shimoda_pollster": 735658100958298154,
   "roles": {
     "agimus_maintainers": "AGIMUS Acolyte",
+    "shimoda_pollsters": "T'Pollsters",
     "reaction_roles_enabled": true,
     "promotion_roles": {
       "required_rank_xp": {

--- a/configuration.json
+++ b/configuration.json
@@ -824,7 +824,6 @@
   "guild_ids": [
     689512841887481875
   ],
-  "shimoda_pollster": 735658100958298154,
   "roles": {
     "agimus_maintainers": "AGIMUS Acolyte",
     "shimoda_pollsters": "T'Pollsters",

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from commands.randomep import randomep
 from commands.reports import reports
 from commands.scores import scores
 from commands.setwager import setwager
+from commands.shimoda import shimoda
 from commands.speak import speak, speak_embed
 from commands.trekduel import trekduel
 from commands.trektalk import trektalk


### PR DESCRIPTION
Users can now use the `/shimoda` command which will bring up a modal they can use to submit Drunk Shimoda nominations for the weekly poll.

Any users with the "T'Pollster" role will be notified with a DM containing the relevant information from the modal form.

![image](https://user-images.githubusercontent.com/1075211/189543378-817fd89c-bd37-4ec5-adb4-1985f20b122f.png)

![image](https://user-images.githubusercontent.com/1075211/189543362-984927fe-e21f-4aa5-ba4c-93684d94c8c4.png)
