### PR TITLE
Fix: Prevent Eventual Error When User Levels Up But Possesses All Badges

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.10.9
-appVersion: v1.10.9
+version: v1.10.10
+appVersion: v1.10.10

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -937,7 +937,7 @@ async def gift_badge(ctx:discord.ApplicationContext, user:discord.User, reason:s
   give a random badge to a user
   """
   await ctx.defer(ephemeral=True)
-  
+
   notification_channel_id = get_channel_id(config["handlers"]["xp"]["notification_channel"])
   logger.info(f"{ctx.author.display_name} is attempting to {Style.BRIGHT}gift a random badge{Style.RESET_ALL} to {user.display_name}")
 
@@ -1036,23 +1036,24 @@ async def gift_specific_badge_error(ctx, error):
 
 
 async def send_badge_reward_message(message:str, embed_description:str, embed_title:str, channel, thumbnail_image:str, badge_filename:str, user:discord.User):
-  badge_info = db_get_badge_info_by_filename(badge_filename)
-
-  badge_name = badge_info['badge_name']
-  badge_url = badge_info['badge_url']
-
   embed=discord.Embed(title=embed_title, description=embed_description, color=discord.Color.random())
-  embed.add_field(
-    name=badge_name,
-    value=badge_url,
-    inline=False
-  )
-  embed.set_thumbnail(url=thumbnail_image)
-  embed.set_footer(text="See all your badges by typing '/badges showcase' - disable this by typing '/settings'")
 
-  embed_filename = str(user.id) + str(abs(hash(badge_name))) + ".png"
-  discord_image = discord.File(fp=f"./images/badges/{badge_filename}", filename=embed_filename)
-  embed.set_image(url=f"attachment://{embed_filename}")
+  if badge_filename != None:
+    badge_info = db_get_badge_info_by_filename(badge_filename)
+    badge_name = badge_info['badge_name']
+    badge_url = badge_info['badge_url']
+
+    embed.add_field(
+      name=badge_name,
+      value=badge_url,
+      inline=False
+    )
+    embed_filename = str(user.id) + str(abs(hash(badge_name))) + ".png"
+    discord_image = discord.File(fp=f"./images/badges/{badge_filename}", filename=embed_filename)
+    embed.set_image(url=f"attachment://{embed_filename}")
+    embed.set_footer(text="See all your badges by typing '/badges showcase' - disable this by typing '/settings'")
+
+  embed.set_thumbnail(url=thumbnail_image)
 
   message = await channel.send(content=message, file=discord_image, embed=embed)
   # Add + emoji so that users can add it as well to add the badge to their wishlist

--- a/handlers/xp.py
+++ b/handlers/xp.py
@@ -263,10 +263,12 @@ async def level_up_user(user:discord.User, level:int):
     vals = (user.id,)
     query.execute(sql, vals)
   badge = give_user_badge(user.id)
-  # Lock the badge if it was in their wishlist
-  db_autolock_badges_by_filenames_if_in_wishlist(user.id, [badge])
-  # Remove any badges the user may have on their wishlist that they now possess
-  db_purge_users_wishlist(user.id)
+
+  if badge != None:
+    # Lock the badge if it was in their wishlist
+    db_autolock_badges_by_filenames_if_in_wishlist(user.id, [badge])
+    # Remove any badges the user may have on their wishlist that they now possess
+    db_purge_users_wishlist(user.id)
 
   await send_level_up_message(user, level, badge)
 
@@ -288,9 +290,13 @@ async def send_level_up_message(user:discord.User, level:int, badge:str):
 
   embed_title = "Level up!"
   thumbnail_image = random.choice(config["handlers"]["xp"]["celebration_images"])
-  embed_description = f"{user.mention} has reached **level {level}** and earned a new badge!"
+  embed_description = f"{user.mention} has reached **level {level}**"
+  if badge == None:
+    embed_description += "! They've already collected ALL BADGES EVERYWHERE! Congratulations on the impressive feat!"
+  else:
+    embed_description += f" and earned a new badge!"
   if level == 2:
-    embed_description = f"{user.mention} has reached **level {level}** and earned their first new unique badge!\n\nCongrats! To check out your full list of badges use `/badges showcase`.\n\nMore info about XP and the badge system and XP can be found by using `/help` in this channel."
+    embed_description += " and earned their first new unique badge!\n\nCongrats! To check out your full list of badges use `/badges showcase`.\n\nMore info about XP and the badge system and XP can be found by using `/help` in this channel."
   message = random.choice(random_level_up_messages["messages"]).format(user=user.mention, level=level, prev_level=(level-1))
   await send_badge_reward_message(message, embed_description, embed_title, channel, thumbnail_image, badge, user)
 


### PR DESCRIPTION
If a user already possesses every badge that we have, the level up message would have errored out while trying to do the badge lookup for a None value. This prevents that from happening.