### PR TITLE
fix .env-example to match Makefile

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -20,7 +20,7 @@ export DB_HOST=host.docker.internal
 # Uncomment next line to run mysql in kubernetes
 # export DB_HOST=mysql-service.agimus.svc.cluster.local
 export DB_NAME=FoD
-export DB_ROOT_PASSWORD=password
+export DB_PASS=password
 export DB_USER=root
 export DB_DUMP_FILENAME=bot-dump.sql
 export DB_CONTAINER_NAME=fodmysql


### PR DESCRIPTION
Fix `.env-example` use to set `DB_PASS` (instead of `DB_ROOT_PASSWORD`) as `Makefile` expects.