### PR TITLE
Feat: Inform Users If Badge Was On Wishlist In Reward Messages

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.10.10
-appVersion: v1.10.10
+version: v1.10.11
+appVersion: v1.10.11

--- a/cogs/wishlist.py
+++ b/cogs/wishlist.py
@@ -211,7 +211,7 @@ class Wishlist(commands.Cog):
       for match in wishlist_matches:
         user_id = match['user_discord_id']
         user_record = wishlist_aggregate.get(user_id)
-        if not user_record:
+        if not user_record and user_id != user_discord_id:
           wishlist_aggregate[user_id] = [match]
         else:
           wishlist_aggregate[user_id].append(match)
@@ -330,7 +330,6 @@ class Wishlist(commands.Cog):
           color=discord.Color.blurple()
         )
       )
-
 
   #    _____       .___  .___
   #   /  _  \    __| _/__| _/

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -950,6 +950,9 @@ async def gift_badge(ctx:discord.ApplicationContext, user:discord.User, reason:s
     ), ephemeral=True)
     return
 
+  user_wishlist_badges = db_get_user_wishlist_badges(user.id)
+  badge_was_on_wishlist = badge in [b['badge_filename'] for b in user_wishlist_badges]
+
   # Lock the badge if it was in their wishlist
   db_autolock_badges_by_filenames_if_in_wishlist(user.id, [badge])
   # Remove any badges the user may have on their wishlist that they now possess
@@ -959,6 +962,8 @@ async def gift_badge(ctx:discord.ApplicationContext, user:discord.User, reason:s
   embed_title = "You got rewarded a free badge!"
   thumbnail_image = random.choice(config["handlers"]["xp"]["celebration_images"])
   embed_description = f"{user.mention} has been gifted a badge by {ctx.author.mention}!"
+  if badge_was_on_wishlist:
+    embed_description += "\n\n" + f" Exciting! It was also one they had on their **wishlist**! {get_emoji('picard_yes_happy_celebrate')}"
   if reason != "":
     message = f"{user.mention} - {strip_emoji(reason)}"
   else:
@@ -1012,6 +1017,9 @@ async def gift_specific_badge(ctx:discord.ApplicationContext, user:discord.User,
     user_badges = db_get_user_badges(user.id)
     badge_filename = badge_info['badge_filename']
     if specific_badge not in [b['badge_name'] for b in user_badges]:
+      user_wishlist_badges = db_get_user_wishlist_badges(user.id)
+      badge_was_on_wishlist = badge_filename in [b['badge_filename'] for b in user_wishlist_badges]
+
       give_user_specific_badge(user.id, badge_filename)
       # Lock the badge if it was in their wishlist
       db_autolock_badges_by_filenames_if_in_wishlist(user.id, [badge_filename])
@@ -1022,6 +1030,9 @@ async def gift_specific_badge(ctx:discord.ApplicationContext, user:discord.User,
   embed_title = "You got rewarded a badge!"
   thumbnail_image = random.choice(config["handlers"]["xp"]["celebration_images"])
   embed_description = f"{user.mention} has been gifted a badge by {ctx.author.mention}!"
+  if badge_was_on_wishlist:
+    embed_description += "\n\n" + f"Exciting! It was also one they had on their **wishlist**! {get_emoji('picard_yes_happy_celebrate')}"
+
   message = f"{user.mention} - Nice work, you got a free badge!"
   await send_badge_reward_message(message, embed_description, embed_title, channel, thumbnail_image, badge_filename, user)
   await ctx.respond("Your gift has been sent!", ephemeral=True)

--- a/handlers/xp.py
+++ b/handlers/xp.py
@@ -3,7 +3,7 @@ from time import sleep
 from numpy import block
 from common import *
 from commands.badges import give_user_badge, send_badge_reward_message
-from queries.wishlist import db_autolock_badges_by_filenames_if_in_wishlist
+from queries.wishlist import db_autolock_badges_by_filenames_if_in_wishlist, db_get_user_wishlist_badges
 from utils.badge_utils import db_get_user_badges, db_purge_users_wishlist
 
 # rainbow of colors to cycle through for the logs
@@ -263,14 +263,17 @@ async def level_up_user(user:discord.User, level:int):
     vals = (user.id,)
     query.execute(sql, vals)
   badge = give_user_badge(user.id)
+  was_on_wishlist = False
 
   if badge != None:
+    user_wishlist_badges = db_get_user_wishlist_badges(user.id)
+    was_on_wishlist = badge in [b['badge_filename'] for b in user_wishlist_badges]
     # Lock the badge if it was in their wishlist
     db_autolock_badges_by_filenames_if_in_wishlist(user.id, [badge])
     # Remove any badges the user may have on their wishlist that they now possess
     db_purge_users_wishlist(user.id)
 
-  await send_level_up_message(user, level, badge)
+  await send_level_up_message(user, level, badge, was_on_wishlist)
 
 def give_welcome_badge(user_id):
   user_badge_names = [b['badge_filename'] for b in db_get_user_badges(user_id)]
@@ -284,19 +287,23 @@ def give_welcome_badge(user_id):
 # user[required]:discord.User
 # level[required]:int
 # badge[required]:str
-async def send_level_up_message(user:discord.User, level:int, badge:str):
+async def send_level_up_message(user:discord.User, level:int, badge:str, was_on_wishlist:bool):
   notification_channel_id = get_channel_id(config["handlers"]["xp"]["notification_channel"])
   channel = bot.get_channel(notification_channel_id)
 
   embed_title = "Level up!"
   thumbnail_image = random.choice(config["handlers"]["xp"]["celebration_images"])
-  embed_description = f"{user.mention} has reached **level {level}**"
+  embed_description = f"{user.mention} has reached **Level {level}**"
   if badge == None:
     embed_description += "! They've already collected ALL BADGES EVERYWHERE! Congratulations on the impressive feat!"
   else:
     embed_description += f" and earned a new badge!"
+
   if level == 2:
     embed_description += " and earned their first new unique badge!\n\nCongrats! To check out your full list of badges use `/badges showcase`.\n\nMore info about XP and the badge system and XP can be found by using `/help` in this channel."
+  if was_on_wishlist:
+    embed_description += "\n\n" + f"Exciting! This was also one they had on their **wishlist**! {get_emoji('picard_yes_happy_celebrate')}"
+
   message = random.choice(random_level_up_messages["messages"]).format(user=user.mention, level=level, prev_level=(level-1))
   await send_badge_reward_message(message, embed_description, embed_title, channel, thumbnail_image, badge, user)
 


### PR DESCRIPTION
Thought this might be nice to indicate to folks that a badge was on someone's wishlist when they receive it. Should cut down on people asking for trades when the receiving user is looking to hold onto them!