### PR TITLE
Feat: Badge Tag Renamer

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.11.0
-appVersion: v1.11.0
+version: v1.11.1
+appVersion: v1.11.1

--- a/data/clips.json
+++ b/data/clips.json
@@ -114,6 +114,11 @@
     "description": "Picard With A Machine Tommy Gun",
     "url": "https://i.imgur.com/lBBMwBG.mp4"
   },
+  "Quark's Is Fun": {
+    "file": "data/clips/quarksisfun.mp4",
+    "description": "Come to Quark's, Quark's is fun, come right now, don't walk, run! Oh I love the part where my name rotates around.",
+    "url": "https://i.imgur.com/vKBlfXo.mp4"
+  },
   "Ransom In The Mariner Ball-Kicking Machine": {
     "file": "data/clips/ransomballkickingmachine.mp4",
     "description": "Mariner Ransom Ball Kicking",

--- a/queries/badge_tags.py
+++ b/queries/badge_tags.py
@@ -37,6 +37,15 @@ def db_delete_user_tag(user_discord_id, tag) -> None:
     vals = (user_discord_id, tag)
     query.execute(sql, vals)
 
+def db_rename_user_tag(user_discord_id, tag, new_name) -> None:
+  """
+  renames a tag for the user in question
+  """
+  with AgimusDB() as query:
+    sql = "UPDATE badge_tags SET tag_name = %s WHERE user_discord_id = %s AND tag_name = %s"
+    vals = (new_name, user_discord_id, tag)
+    query.execute(sql, vals)
+
 def db_get_associated_badge_tags(user_discord_id, badge_name) -> list:
   """
   returns a list of the current tags the user has associated with a given badge


### PR DESCRIPTION
Users can now use `/tags rename <tag> <new_name>` to change the name of an existing tag they have.

Also threw in a small clip update while I was here.