### PR TITLE
Fix Auto Badge Updater

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,24 +243,7 @@ helm-bump-major: ## Bump-major the semantic version of the helm chart using semv
 .PHONY: update-badges
 update-badges: ## Run the automated badge updater script, then commit the changes to a new branch and push
 	@echo "Updating badges!"
-	git checkout -b badge_updates/v$(shell semver bump minor $(shell yq e '.version' charts/agimus/Chart.yaml));
-	@python badge_updater.py
-
-	@status=$$(git status images --porcelain); \
-	if test "x$${status}" != x; then \
-		sed -i 's/'$(shell yq e '.version' charts/agimus/Chart.yaml)'/v'$(shell semver bump minor $(shell yq e '.version' charts/agimus/Chart.yaml))'/g' charts/agimus/Chart.yaml; \
-		git add charts \
-			&& git add migrations \
-				&& git add images \
-				&& git commit -m "Committing Badge Update for v$(shell semver bump minor $(shell yq e '.version' charts/agimus/Chart.yaml)) - $(shell date)" \
-				&& git push --set-upstream https://$(GIT_TOKEN)@github.com/$(REPO_OWNER)/$(REPO_NAME).git badge_updates/v$(shell semver bump minor $(shell yq e '.version' charts/agimus/Chart.yaml)) \
-				&& git checkout main; \
-			echo "Badge Update Success"; \
-	else \
-		git checkout main \
-			&& git branch -D badge_updates/v$(shell semver bump minor $(shell yq e '.version' charts/agimus/Chart.yaml)); \
-		echo "No-op"; \
-	fi
+	@sh update_badges.sh
 
 .PHONY: update-shows
 update-shows: ## Update the TGG metadata in the database via github action

--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.14.6
-appVersion: v1.14.6
+version: v1.14.7
+appVersion: v1.14.7

--- a/common.py
+++ b/common.py
@@ -352,7 +352,8 @@ def run_make_badger():
   result = {
     "completed": False,
     "error": False,
-    "version": ""
+    "version": "",
+    "log": ""
   }
   try:
     process = subprocess.Popen(['make', 'update-badges'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True)
@@ -362,13 +363,19 @@ def run_make_badger():
       result['completed'] = True
       version_match = re.search(r'New version: (v\d+\.\d+.\d+)', log)
       result['version'] = version_match.group(1)
+    elif 'fatal' in log:
+      result['completed'] = False
+      fatal_match = re.search(r'fatal: (.*)\n', log)
+      result['error'] = fatal_match.group(1)
     else:
       result['completed'] = False
+    result['log'] = log
     return result
   except Exception as e:
     logger.info(e)
     result['completed'] = False
     result['error'] = stderr.decode('utf-8')
+    result['log'] = stdout.decode('utf-8')
     return result
 
 # returns a pretend stardate based on the given datetime

--- a/tasks/badger.py
+++ b/tasks/badger.py
@@ -8,8 +8,9 @@ def badger_task(client):
       return
 
     repo_base_url = f"https://github.com/{os.getenv('REPO_OWNER')}/{os.getenv('REPO_NAME')}"
-    log_channel = client.get_channel(config["channels"]["bot-logs"])
     logger.info("Running automated badge update!")
+    log_channel = client.get_channel(LOGGING_CHANNEL)
+    acolytes_channel = client.get_channel(DEV_CHANNEL)
 
     result = run_make_badger()
     if not result['completed']:
@@ -27,6 +28,7 @@ def badger_task(client):
           color=discord.Color.random(),
           description="🚫 No new badges found, no update needed! 🚫",
         )
+      await log_channel.send(embed=embed)
 
     else:
       logger.info(f"Automated badge update branch creation complete, new version: {result['version']}")
@@ -42,7 +44,8 @@ def badger_task(client):
       embed.add_field(name="🌟 NEW BADGE UPDATE VERSION 🌟", value=f"`{result['version']}`", inline=False)
       embed.add_field(name="GitHub URL to create PR", value=pull_request_url, inline=False)
 
-    await log_channel.send(embed=embed)
+      await log_channel.send(embed=embed)
+      await acolytes_channel.send(embed=embed)
 
   return {
     "task": badger,

--- a/update_badges.sh
+++ b/update_badges.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Update Badges
+NEW_BADGES_BRANCH_NAME="badge_updates/v$(semver bump minor $(yq e '.version' charts/agimus/Chart.yaml))"
+
+if [ `git rev-parse --verify $NEW_BADGES_BRANCH_NAME 2>/dev/null` ]; then
+  echo "fatal: New badge update branch already exists locally, check github to merge the current update branch: $NEW_BADGES_BRANCH_NAME"
+elif [ `git ls-remote --heads git@github.com:$REPO_OWNER/$REPO_NAME.git $NEW_BADGES_BRANCH_NAME | wc -l` ]; then
+  echo "fatal: New badge update branch already exists remotely, check github to merge the current update branch: $NEW_BADGES_BRANCH_NAME"
+else
+  echo "No current branch in progress, running script."
+  git checkout -b $NEW_BADGES_BRANCH_NAME
+  python3 badge_updater.py
+
+	if [[ $(git status images --porcelain) ]]; then
+		make helm-bump-minor
+		git add charts \
+			&& git add migrations \
+				&& git add images \
+				&& git commit -m "Committing Badge Update for v$(semver bump minor $(yq e '.version' charts/agimus/Chart.yaml)) - $(date)" \
+				&& git push --set-upstream https://$GIT_TOKEN@github.com/$REPO_OWNER/$REPO_NAME.git $NEW_BADGES_BRANCH_NAME \
+				&& git checkout main;
+		echo "Badge Update Success"
+	else
+		git checkout main \
+			&& git branch -D badge_updates/v$(semver bump minor $(yq e '.version' charts/agimus/Chart.yaml));
+		echo "No-op"
+	fi
+fi


### PR DESCRIPTION
Move the badge updater make instructions to a separate script. Check if the branch already exists locally or remotely before doing the business. Log full details to log channel.