### PR TITLE
Update configuration.json

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -88,7 +88,8 @@
         "faith-of-the-heart": [
           "love",
           "heart",
-          "hearts"
+          "hearts",
+          "black_heart"
         ]
       }
     },


### PR DESCRIPTION
Added black_heart to the list of emoji for faith of the heart channel. Unclear why this wasn't working already, since it should just look for "heart" in the name? Maybe the underscore throws it off? Who knows, man.