### PR TITLE
Rename "Shop Sign a (Qualor II)" to "Retail Sign A (Qualor II)"

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.16.0
-appVersion: v1.16.0
+version: v1.17.0
+appVersion: v1.17.0

--- a/migrations/v1.17.0.sql
+++ b/migrations/v1.17.0.sql
@@ -1,0 +1,1 @@
+UPDATE badge_info SET badge_name = "Retail Sign A (Qualor II)" WHERE badge_filename = "Shop-Sign-A-_Qualor-II.png";


### PR DESCRIPTION
With the latest badge update, STDP changed the name of "Shop Sign a (Qualor II)" to "Retail Sign A (Qualor II)" along with adding the B, C, and D variants.

This migration script renames the badge_name in our DB to match. 🎉 