### PR TITLE
Fix Self Wishlist Matches

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.17.1
-appVersion: v1.17.1
+version: v1.17.2
+appVersion: v1.17.2

--- a/cogs/wishlist.py
+++ b/cogs/wishlist.py
@@ -204,12 +204,16 @@ class Wishlist(commands.Cog):
 
     logger.info(f"{ctx.author.display_name} is checking for {Style.BRIGHT}matches{Style.RESET_ALL} to their {Style.BRIGHT}wishlist{Style.RESET_ALL}")
 
+    # Housekeeping
+    # Clear any badges from the users wishlist that the user may already possess currently
+    db_purge_users_wishlist(author_discord_id)
+
     # Get all the users and the badgenames that have the badges the user wants
     wishlist_matches = db_get_wishlist_matches(author_discord_id)
     wishlist_aggregate = {}
     if wishlist_matches:
       for match in wishlist_matches:
-        user_id = match['user_discord_id']
+        user_id = int(match['user_discord_id'])
         if user_id == author_discord_id:
           continue
 
@@ -224,12 +228,12 @@ class Wishlist(commands.Cog):
     inventory_aggregate = {}
     if inventory_matches:
       for match in inventory_matches:
-        user_id = match['user_discord_id']
+        user_id = int(match['user_discord_id'])
         if user_id == author_discord_id:
           continue
 
         user_record = inventory_aggregate.get(user_id)
-        if not user_record and user_id != author_discord_id:
+        if not user_record:
           inventory_aggregate[user_id] = [match]
         else:
           inventory_aggregate[user_id].append(match)

--- a/cogs/wishlist.py
+++ b/cogs/wishlist.py
@@ -200,30 +200,36 @@ class Wishlist(commands.Cog):
   @commands.check(access_check)
   async def matches(self, ctx:discord.ApplicationContext):
     await ctx.defer(ephemeral=True)
-    user_discord_id = ctx.author.id
+    author_discord_id = ctx.author.id
 
     logger.info(f"{ctx.author.display_name} is checking for {Style.BRIGHT}matches{Style.RESET_ALL} to their {Style.BRIGHT}wishlist{Style.RESET_ALL}")
 
     # Get all the users and the badgenames that have the badges the user wants
-    wishlist_matches = db_get_wishlist_matches(user_discord_id)
+    wishlist_matches = db_get_wishlist_matches(author_discord_id)
     wishlist_aggregate = {}
     if wishlist_matches:
       for match in wishlist_matches:
         user_id = match['user_discord_id']
+        if user_id == author_discord_id:
+          continue
+
         user_record = wishlist_aggregate.get(user_id)
-        if not user_record and user_id != user_discord_id:
+        if not user_record:
           wishlist_aggregate[user_id] = [match]
         else:
           wishlist_aggregate[user_id].append(match)
 
     # Get all the users and the badgenames that want badges that the user has
-    inventory_matches = db_get_wishlist_inventory_matches(user_discord_id)
+    inventory_matches = db_get_wishlist_inventory_matches(author_discord_id)
     inventory_aggregate = {}
     if inventory_matches:
       for match in inventory_matches:
         user_id = match['user_discord_id']
+        if user_id == author_discord_id:
+          continue
+
         user_record = inventory_aggregate.get(user_id)
-        if not user_record:
+        if not user_record and user_id != author_discord_id:
           inventory_aggregate[user_id] = [match]
         else:
           inventory_aggregate[user_id].append(match)

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -528,6 +528,10 @@ class ScrapButton(discord.ui.Button):
       # Do the actual scrappage
       db_perform_badge_scrap(self.user_id, self.badge_to_add, self.badges_to_scrap)
 
+      # Housekeeping
+      # Clear any badges from the users wishlist that the user may now possess
+      db_purge_users_wishlist(self.user_id)
+
       # Post message about successful scrap
       scrapper_gif = await generate_badge_scrapper_result_gif(self.user_id, self.badge_to_add)
 


### PR DESCRIPTION
See #374 

Where we were supposed to be filtering out the command initiator it was doing a string vs int comparison 🤦 

Went ahead and also fired off a wishlist purge when the command is run as well for good measure (simply clears out a users wishlist of any badges that they currently already possess, so the later checks should now only provide redundancy).

We should also run the purge when a user receives a new scrap badge so adding that as well.