### PR TITLE
Update Welcome Message Channel

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.20.1
-appVersion: v1.20.1
+version: v1.20.2
+appVersion: v1.20.2

--- a/configuration.json
+++ b/configuration.json
@@ -62,6 +62,7 @@
         "rikers-quarters",
         "mo-pips-mo-problemz",
         "mclaughlin-group",
+        "lieutenants-lounge",
         "captains-log",
         "bot-setup",
         "shipwide-announcements",
@@ -295,6 +296,7 @@
     },
     "reports": {
       "channels": [
+        "lieutenants-lounge",
         "mclaughlin-group",
         "mo-pips-mo-problems",
         "robot-diagnostics"
@@ -840,6 +842,7 @@
   "server_logs_channel": "captains-log",
   "agimus_announcement_channel": "crackling-speaker-grille",
   "admin_channel": "mo-pips-mo-problemz",
+  "welcome_channel": "lieutenants-lounge",
   "mods_channel": "mclaughlin-group",
   "guild_ids": [
     689512841887481875

--- a/data/drops.json
+++ b/data/drops.json
@@ -305,7 +305,7 @@
     "url": "https://i.imgur.com/QfFyGxz.mp4"
   },
   "PODSHOP DOT BIZ": {
-    "file": "data/drops/micfeedback.mp4",
+    "file": "data/drops/podshopdotbiz.mp4",
     "description": "Podshop Dot Biz podshop.biz",
     "url": "https://i.imgur.com/ps11rjE.mp4"
   },  

--- a/handlers/xp.py
+++ b/handlers/xp.py
@@ -146,8 +146,8 @@ async def handle_intro_channel_promotion(message):
       welcome_embed.add_field(name=f"Bring them into the fold {get_emoji('kira_good_morning_hello')}", value=f"Let them know it's okay to jump in anywhere, anytime. Offer a channel for them to get started on! (like <#{get_channel_id(config['channels']['animal-holophotography'])}>)", inline=False)
 
       welcome_embed.set_footer(text="Thank you officers! 💖")
-      mods_channel = bot.get_channel(get_channel_id(config["mods_channel"]))
-      await mods_channel.send(content=f"@here -- attention senior officers! {message.author.mention} has just posted an intro!\n\n", embed=welcome_embed)
+      welcome_channel = bot.get_channel(get_channel_id(config["welcome_channel"]))
+      await welcome_channel.send(content=f"@here -- attention senior officers! {message.author.mention} has just posted an intro!\n\n", embed=welcome_embed)
 
 # If they've hit an XP threshold, auto-promote to general ranks
 async def handle_rank_xp_promotion(message, xp):


### PR DESCRIPTION
With the new role changes for Lt. Commander and Lieutenants, moving the welcome message Aggy sends to the new #lieutenants-lounge channel rather than #mclaughlin-group.

Also fixed an error in the `drops.json` file where PODSHOP DOT BIZ was being saved over micfeedback.mp4