### PR TITLE
Simplify the migration makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ db-load: ## Load the database from a file at $DB_DUMP_FILENAME
 	@docker-compose exec -T app mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) $(DB_NAME) < $(DB_DUMP_FILENAME)
 
 .PHONY: db-migrate
-db-migrate: ## Apply a migration/sql file to the database from a file at ./migrations/v#.#.#.sql
-	@docker-compose exec -T app mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) $(DB_NAME) < ./migrations/$(shell make version).sql
+db-migrate: ## Apply a migration/sql file to the database from a file at the filepath saved in $(MIGRATION_FILE)
+	@docker-compose exec -T app mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) $(DB_NAME) < $(MIGRATION_FILE)
 
 .PHONY: db-seed
 db-seed: ## Reload the database from a file at $DB_SEED_FILEPATH
@@ -205,9 +205,9 @@ helm-db-load: ## Load the database from a file at $DB_SEED_FILEPATH
 		-- bash -c 'exec mysql -h127.0.0.1 -u"${DB_USER}" -p"${DB_PASS}"' < ${DB_SEED_FILEPATH}
 
 .PHONY: helm-db-migrate
-helm-db-migrate: ## Load the database from a file at $DB_SEED_FILEPATH
+helm-db-migrate: ## Load the database from a file at the filepath saved in $(MIGRATION_FILE)
 	@kubectl --namespace $(namespace) exec -i $(shell make --no-print-directory helm-db-pod) \
-		-- bash -c 'exec mysql -h127.0.0.1 -u"${DB_USER}" -p"${DB_PASS}" ${DB_NAME}' < ./migrations/$(shell --no-print-directory make version).sql
+		-- bash -c 'exec mysql -h127.0.0.1 -u"${DB_USER}" -p"${DB_PASS}" ${DB_NAME}' < $(MIGRATION_FILE)
 
 .PHONY: helm-db-mysql
 helm-db-mysql: ## Mysql session in mysql pod

--- a/README.md
+++ b/README.md
@@ -306,8 +306,14 @@ The easiest way to apply [migrations](migrations), is to override the entrypoint
 # Pull environment variables secrets
 source .env
 
-# Run an arbitrary migration sql
-mysql -u$DB_USER -p$DB_PASS -h$DB_HOST FoD < ./migrations/v#.#.#.sql
+# Set the migration file to set
+export MIGRATION_FILE='./migrations/v1.3.18.sql'
+
+# Run an arbitrary migration sql (docker)
+make db-migrate
+
+# Run an arbitrary migration sql (kubernetes)
+make helm-db-migrate
 
 # Restore from backup a specific commit in repo https://github.com/Friends-of-DeSoto/database
 DB_BACKUP_RESTORE_COMMIT=abcdefghijklmnopqrstuvwxyz make db-restore

--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.21.1
-appVersion: v1.21.1
+version: v1.21.3
+appVersion: v1.21.3


### PR DESCRIPTION
This change will make it easier to run migration files against docker and kubernetes based mysql deployments. These targets currently assume the user is only one migration behind. This isn't very flexible or realistic in practice. Instead this change will allow the user to set the migration file they want to run by exporting an environment variable first

```bash
# Set the migration file to set
export MIGRATION_FILE='./migrations/v1.3.18.sql'

# Run an arbitrary migration sql (docker)
make db-migrate

# Run an arbitrary migration sql (kubernetes)
make helm-db-migrate
```