### PR TITLE
Allow Users To Dismiss Wishlist Matches

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.23.0
-appVersion: v1.23.0
+version: v1.23.1
+appVersion: v1.23.1

--- a/cogs/wishlist.py
+++ b/cogs/wishlist.py
@@ -79,9 +79,10 @@ class DismissButton(discord.ui.Button):
   async def callback(self, interaction: discord.Interaction):
     db_add_wishlist_dismissal(self.author_discord_id, self.match_discord_id, self.has, self.wants)
     await self.view.message.delete()
+    match_user = await bot.current_guild.fetch_member(self.match_discord_id)
     await interaction.response.send_message(
       embed=discord.Embed(
-        title="This wishlist match has been dismissed.",
+        title=f"Your wishlist match with {match_user.display_name} has been dismissed.",
         description="If new badges are found in the future the dismissal will be automatically cleared."
       ),
       ephemeral=True

--- a/data/seed-db.sql
+++ b/data/seed-db.sql
@@ -267,3 +267,12 @@ CREATE TABLE IF NOT EXISTS badge_tags_associations (
   KEY `badge_tags_id` (`badge_tags_id`),
   CONSTRAINT `badge_tags_associations_fk_badge_tags_id` FOREIGN KEY (`badge_tags_id`) REFERENCES `badge_tags` (`id`) ON DELETE CASCADE
 );
+CREATE TABLE IF NOT EXISTS wishlist_dismissals (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_discord_id` varchar(64) NOT NULL,
+  `match_user_discord_id` varchar(64) NOT NULL,
+  `user_has` JSON NOT NULL,
+  `user_wants` JSON NOT NULL,
+  `time_created` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`)
+)

--- a/data/seed-db.sql
+++ b/data/seed-db.sql
@@ -270,9 +270,9 @@ CREATE TABLE IF NOT EXISTS badge_tags_associations (
 CREATE TABLE IF NOT EXISTS wishlist_dismissals (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_discord_id` varchar(64) NOT NULL,
-  `match_user_discord_id` varchar(64) NOT NULL,
-  `user_has` JSON NOT NULL,
-  `user_wants` JSON NOT NULL,
+  `match_discord_id` varchar(64) NOT NULL,
+  `has` JSON NOT NULL,
+  `wants` JSON NOT NULL,
   `time_created` timestamp NOT NULL DEFAULT current_timestamp(),
   PRIMARY KEY (`id`)
 )

--- a/queries/wishlist.py
+++ b/queries/wishlist.py
@@ -196,3 +196,37 @@ def db_get_wishlist_inventory_matches(user_discord_id):
     query.execute(sql, vals)
     results = query.fetchall()
   return results
+
+
+# ________  .__               .__                      .__          
+# \______ \ |__| ______ _____ |__| ______ ___________  |  |   ______
+#  |    |  \|  |/  ___//     \|  |/  ___//  ___/\__  \ |  |  /  ___/
+#  |    `   \  |\___ \|  Y Y  \  |\___ \ \___ \  / __ \|  |__\___ \ 
+# /_______  /__/____  >__|_|  /__/____  >____  >(____  /____/____  >
+#         \/        \/      \/        \/     \/      \/          \/ 
+def db_get_wishlist_dismissal(user_discord_id, match_discord_id):
+  with AgimusDB(dictionary=True) as query:
+    sql = '''
+      SELECT * FROM wishlist_dismissals WHERE user_discord_id = %s AND match_discord_id = %s;
+    '''
+    vals = (user_discord_id, match_discord_id)
+    query.execute(sql, vals)
+    results = query.fetchall()
+  return results
+
+def db_delete_wishlist_dismissal(user_discord_id, match_discord_id):
+  with AgimusDB(dictionary=True) as query:
+    sql = '''
+      DELETE FROM wishlist_dismissals WHERE user_discord_id = %s AND match_discord_id = %s;
+    '''
+    vals = (user_discord_id, match_discord_id)
+    query.execute(sql, vals)
+
+def db_add_wishlist_dismissal(user_discord_id, match_discord_id, has, wants):
+  with AgimusDB() as query:
+    sql = '''
+      INSERT INTO wishlist_dismissals (user_discord_id, match_discord_id, has, wants)
+        VALUES (%s, %s, %s, %s)
+    '''
+    vals = (user_discord_id, match_discord_id, has, wants)
+    query.execute(sql, vals)

--- a/queries/wishlist.py
+++ b/queries/wishlist.py
@@ -198,12 +198,12 @@ def db_get_wishlist_inventory_matches(user_discord_id):
   return results
 
 
-# ________  .__               .__                      .__          
+# ________  .__               .__                      .__
 # \______ \ |__| ______ _____ |__| ______ ___________  |  |   ______
 #  |    |  \|  |/  ___//     \|  |/  ___//  ___/\__  \ |  |  /  ___/
-#  |    `   \  |\___ \|  Y Y  \  |\___ \ \___ \  / __ \|  |__\___ \ 
+#  |    `   \  |\___ \|  Y Y  \  |\___ \ \___ \  / __ \|  |__\___ \
 # /_______  /__/____  >__|_|  /__/____  >____  >(____  /____/____  >
-#         \/        \/      \/        \/     \/      \/          \/ 
+#         \/        \/      \/        \/     \/      \/          \/
 def db_get_wishlist_dismissal(user_discord_id, match_discord_id):
   with AgimusDB(dictionary=True) as query:
     sql = '''
@@ -211,7 +211,7 @@ def db_get_wishlist_dismissal(user_discord_id, match_discord_id):
     '''
     vals = (user_discord_id, match_discord_id)
     query.execute(sql, vals)
-    results = query.fetchall()
+    results = query.fetchone()
   return results
 
 def db_delete_wishlist_dismissal(user_discord_id, match_discord_id):


### PR DESCRIPTION
Allows users to dismiss a wishlist match. If new badges are found that either party wants/has then the dismissal is revoked on the next `/wishlist matches`.

![image](https://user-images.githubusercontent.com/1075211/230676277-32c71ccd-a833-4f25-bac6-908f1f214dd4.png)

![image](https://user-images.githubusercontent.com/1075211/230676294-0df7c7d0-e659-4f9e-a487-d045bf0e4a06.png)
