### PR TITLE
Log Global Username Changes

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.24.3
-appVersion: v1.24.3
+version: v1.24.4
+appVersion: v1.24.4

--- a/commands/aliases.py
+++ b/commands/aliases.py
@@ -1,0 +1,61 @@
+from common import *
+from utils.check_channel_access import access_check
+from pytz import timezone
+import pytz
+
+@bot.slash_command(
+  name="aliases",
+  description="View User Aliases (ADMIN ONLY)"
+)
+@option(
+  "user",
+  discord.User,
+  description="The user you wish to view past aliases of",
+  required=True
+)
+@commands.check(access_check)
+async def aliases(ctx:discord.ApplicationContext, user:discord.User):
+  aliases = db_get_user_aliases(user.id)
+
+  if not aliases:
+    await ctx.respond(embed=discord.Embed(
+      title=f"{user.display_name} has no logged aliases!",
+      color=discord.Color.red()
+    ), ephemeral=True)
+    return
+
+  old_aliases = "\n".join([a['old_alias'] for a in aliases])
+  new_aliases = "\n".join([a['new_alias'] for a in aliases])
+
+  pst_tz = timezone('US/Pacific')
+
+  raw_timestamps = [pytz.utc.localize(a['time_created']) for a in aliases]
+  aware_timestamps = [pst_tz.normalize(t.astimezone(pst_tz)) for t in raw_timestamps]
+  dates_changed = "\n".join([t.strftime("%B %d, %Y - %I:%M %p") for t in aware_timestamps])
+
+  embed = discord.Embed(
+    title=f"{user.display_name}'s Known Aliases",
+    color=discord.Color.purple()
+  )
+  embed.add_field(
+    name=f"Previous Alias",
+    value=old_aliases
+  )
+  embed.add_field(
+    name=f"New Alias",
+    value=new_aliases
+  )
+  embed.add_field(
+    name=f"Date Changed",
+    value=dates_changed
+  )
+  await ctx.respond(embed=embed, ephemeral=True)
+
+
+def db_get_user_aliases(user_discord_id):
+  with AgimusDB(dictionary=True) as query:
+    sql = "SELECT * FROM user_aliases WHERE user_discord_id = %s ORDER BY time_created ASC;"
+    vals = (user_discord_id,)
+    query.execute(sql, vals)
+    aliases = query.fetchall()
+  return aliases

--- a/configuration.json
+++ b/configuration.json
@@ -326,6 +326,16 @@
       "openai_model": "text-davinci-002",
       "parameters": []
     },
+    "aliases": {
+      "channels": [
+        "mclaughlin-group",
+        "mo-pips-mo-problemz",
+        "code-47",
+        "robot-diagnostics"
+      ],
+      "enabled": true,
+      "parameters": []
+    },
     "reports": {
       "channels": [
         "lieutenants-lounge",

--- a/data/seed-db.sql
+++ b/data/seed-db.sql
@@ -284,3 +284,11 @@ CREATE TABLE IF NOT EXISTS randomep_selections (
   PRIMARY KEY (`id`),
   UNIQUE (`user_discord_id`)
 );
+CREATE TABLE IF NOT EXISTS user_aliases (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_discord_id` varchar(64) NOT NULL,
+  `old_alias` varchar(64) NOT NULL,
+  `new_alias` varchar(64) NOT NULL,
+  `time_created` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`)
+);

--- a/handlers/server_logs.py
+++ b/handlers/server_logs.py
@@ -27,13 +27,13 @@ async def show_leave_message(member:discord.Member):
 # shows a message when someone changes their nickname on the server
 # before[required]: discord.Member
 # after[required]: discord.Member
-async def show_nick_change_message(before,after):
+async def show_nick_change_message(before, after, scope = ""):
   if before.bot or after.bot:
     return
 
   server_log_channel = bot.get_channel(SERVER_LOGS_CHANNEL)
   msg = f"**{before.display_name}** has changed their nickname to: **{after.display_name}**"
-  logger.info(f"{Fore.LIGHTGREEN_EX}{before.display_name}{Fore.RESET} has changed their nickname to: {Fore.GREEN}{after.display_name}{Fore.RESET}")
+  logger.info(f"{Fore.LIGHTGREEN_EX}{before.display_name}{Fore.RESET} has changed their {scope} nickname to: {Fore.GREEN}{after.display_name}{Fore.RESET}")
   await server_log_channel.send(msg)
 
 # show_channel_creation_message(channel)

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from common import *
 import aiohttp
 
 # Slash Commands
+from commands.aliases import aliases
 from commands.badges import *
 from commands.dustbuster import dustbuster
 from commands.fmk import fmk
@@ -269,14 +270,14 @@ async def on_member_remove(member):
 
 # listen to nickname change events
 @bot.event
-async def on_member_update(memberBefore,memberAfter):
+async def on_member_update(memberBefore, memberAfter):
   if memberBefore.nick != memberAfter.nick:
     await show_nick_change_message(memberBefore, memberAfter, "server")
 
 @bot.event
-async def on_user_update(memberBefore,memberAfter):
-  if memberBefore.nick != memberAfter.nick:
-    await show_nick_change_message(memberBefore, memberAfter, "Discord")
+async def on_user_update(userBefore, userAfter):
+  if userBefore.display_name != userAfter.display_name:
+    await show_nick_change_message(userBefore, userAfter, "Discord")
 
 # Listen to channel updates
 @bot.event

--- a/main.py
+++ b/main.py
@@ -271,7 +271,12 @@ async def on_member_remove(member):
 @bot.event
 async def on_member_update(memberBefore,memberAfter):
   if memberBefore.nick != memberAfter.nick:
-    await show_nick_change_message(memberBefore, memberAfter)
+    await show_nick_change_message(memberBefore, memberAfter, "server")
+
+@bot.event
+async def on_user_update(memberBefore,memberAfter):
+  if memberBefore.nick != memberAfter.nick:
+    await show_nick_change_message(memberBefore, memberAfter, "Discord")
 
 # Listen to channel updates
 @bot.event


### PR DESCRIPTION
Previously we were only logging when a user's local server nick changed, we now track if they change their outright Discord username as well.

Additionally, added an `/aliases` command that mods can use to view a user's past nickname changes via a new db table (only tracks going forward from when this is implemented).

![image](https://user-images.githubusercontent.com/1075211/233754967-b44422c7-d0e1-4ee3-bcdd-491f8df6332a.png)
