### PR TITLE
Fix `/badges completion` Row Badge Images

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.24.6
-appVersion: v1.24.6
+version: v1.24.7
+appVersion: v1.24.7

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -448,21 +448,22 @@ async def completion(ctx:discord.ApplicationContext, public:str, category:str, c
         await ctx.followup.send(files=chunk, ephemeral=not public)
 
 def _append_featured_completion_badges(user_id, report, category):
-    if category == "affiliation":
-      badges = db_get_random_badges_from_user_by_affiliations(user_id)
-    elif category == "franchise":
-      badges = db_get_random_badges_from_user_by_franchises(user_id)
-    elif category == "time_period":
-      badges = db_get_random_badges_from_user_by_time_periods(user_id)
-    elif category == "type":
-      badges = db_get_random_badges_from_user_by_types(user_id)
-    else:
-      badges = {}
+  if category == "affiliation":
+    badges = db_get_random_badges_from_user_by_affiliations(user_id)
+  elif category == "franchise":
+    badges = db_get_random_badges_from_user_by_franchises(user_id)
+  elif category == "time_period":
+    badges = db_get_random_badges_from_user_by_time_periods(user_id)
+  elif category == "type":
+    badges = db_get_random_badges_from_user_by_types(user_id)
+  else:
+    badges = {}
 
-    for r in report:
-      if r['name'] in badges:
-        r['featured_badge'] = badges.get(r['name'])
-        return report
+  for r in report:
+    if r['name'] in badges:
+      r['featured_badge'] = badges.get(r['name'])
+
+  return report
 
 
 #   _________


### PR DESCRIPTION
Indentation problem here with an early return so only the first row was getting the badge filename appended. Oops.

## Before
![image](https://user-images.githubusercontent.com/1075211/234357177-79f45246-ddec-4763-92fb-c3c568df5fdb.png)

## After
![image](https://user-images.githubusercontent.com/1075211/234357260-6cd0cede-c00e-4475-8cba-cfbf2ce65053.png)
