### PR TITLE
New Pin and Unpin Context Menu Commands for Lt. Commanders

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.24.7
-appVersion: v1.24.7
+version: v1.24.8
+appVersion: v1.24.8

--- a/commands/pin.py
+++ b/commands/pin.py
@@ -1,0 +1,29 @@
+from common import *
+from utils.check_role_access import role_check
+
+@bot.message_command(
+  name="pin",
+  description="Pin (Admin Only)"
+)
+@commands.check(role_check)
+async def pin(ctx, message: discord.Message):
+  logger.info(f"{ctx.author.display_name} is pinning message {message.id} in {ctx.channel.name}")
+  if message.pinned:
+    await ctx.respond(f"Whoa there, this message is already pinned! No action taken.", ephemeral=True)
+  else:
+    await message.pin()
+    await ctx.respond(f"Message pinned! 📌", ephemeral=True)
+
+
+@bot.message_command(
+  name="unpin",
+  description="Unpin (Admin Only)"
+)
+@commands.check(role_check)
+async def unpin(ctx, message: discord.Message):
+  logger.info(f"{ctx.author.display_name} is unpinning message {message.id} in {ctx.channel.name}")
+  if not message.pinned:
+    await ctx.respond(f"Whoa there, can't unpin this message because it is not already pinned! No action taken.", ephemeral=True)
+  else:
+    await message.unpin()
+    await ctx.respond(f"Message unpinned! 💢", ephemeral=True)

--- a/common.py
+++ b/common.py
@@ -113,6 +113,23 @@ LOGGING_CHANNEL = get_channel_id(config["logging_channel"])
 SERVER_LOGS_CHANNEL = get_channel_id(config["server_logs_channel"])
 
 
+# Role Helpers
+def get_role_ids_list(role_list):
+  role_list = list(role_list)
+  role_list.sort()
+  role_ids = []
+  for x in role_list:
+    id = get_role_id(x)
+    role_ids.append(id)
+  return role_ids
+
+def get_role_id(role_identifier):
+  if isinstance(role_identifier, str):
+    id = config["role_map"].get(role_identifier)
+  else:
+    id = role_identifier
+  return id
+
 # ________          __        ___.
 # \______ \ _____ _/  |______ \_ |__ _____    ______ ____
 #  |    |  \\__  \\   __\__  \ | __ \\__  \  /  ___// __ \
@@ -321,6 +338,20 @@ def generate_local_channel_list(client):
     # channel_list_json = json.dumps(channel_list, indent=2, sort_keys=True)
     updated_channel_list = deep_dict_update({ "channels": config['channels'] }, { "channels" : channel_list })
     config["channels"] = updated_channel_list["channels"]
+
+# generate_local_role_map(client)
+# client[required]: discord.Bot
+# This runs to apply the local role map (name to id) on top of the existing role map config
+def generate_local_role_map(client):
+  if client.guilds[0]:
+    roles = client.guilds[0].roles
+    role_map = {}
+    for role in roles:
+      role_name = role.name.encode("ascii", errors="ignore").decode().strip()
+      role_map[role_name] = role.id
+    # role_map_json = json.dumps(role_map, indent=2, sort_keys=True)
+    updated_role_map = deep_dict_update({ "role_map": config['role_map'] }, { "role_map" : role_map })
+    config["role_map"] = updated_role_map["role_map"]
 
 # get_emoji(emoji_name)
 # emoji_name[required]: str

--- a/configuration.json
+++ b/configuration.json
@@ -493,6 +493,17 @@
       "data": null,
       "parameters": []
     },
+    "pin": {
+      "allowed_roles": [
+        "Admiral",
+        "Captain",
+        "Commander",
+        "Lt. Commander"
+      ],
+      "enabled": true,
+      "data": null,
+      "parameters": []
+    },
     "ping": {
       "channels": [
         "robot-diagnostics"
@@ -847,6 +858,17 @@
       "data": "data/all_characters.txt",
       "parameters": []
     },
+    "unpin": {
+      "allowed_roles": [
+        "Admiral",
+        "Captain",
+        "Commander",
+        "Lt. Commander"
+      ],
+      "enabled": true,
+      "data": null,
+      "parameters": []
+    },
     "update_status": {
       "channels": [],
       "enabled": true,
@@ -898,6 +920,7 @@
   "guild_ids": [
     689512841887481875
   ],
+  "role_map": {},
   "roles": {
     "agimus_maintainers": "AGIMUS Acolyte",
     "shimoda_pollsters": "T'Pollsters",

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from commands.help import help
 from commands.info import info
 from commands.nasa import nasa
 from commands.nextep import nextep, nexttrek
+from commands.pin import pin, unpin
 from commands.reports import reports
 from commands.scores import scores
 from commands.setwager import setwager
@@ -209,9 +210,11 @@ async def on_ready():
     logger.info(f"{Fore.LIGHTMAGENTA_EX}BOT IS ONLINE AND READY FOR COMMANDS!{Fore.RESET}")
     logger.info(f"{Fore.LIGHTRED_EX}CURRENT NUMBER OF STARBOARD POSTS:{Fore.RESET}{Style.BRIGHT} {Fore.BLUE}{number_of_starboard_posts}{Fore.RESET}{Style.RESET_ALL}")
 
+    bot.current_guild = bot.guilds[0]
     # generate local channels list
     generate_local_channel_list(bot)
-    bot.current_guild = bot.guilds[0]
+    # generate local roles map
+    generate_local_role_map(bot)
 
     # Set a fun random presence
     random_presences = [

--- a/utils/check_role_access.py
+++ b/utils/check_role_access.py
@@ -1,0 +1,24 @@
+from common import *
+
+# @commands.check decorator function
+# Can be injected in between @commands.check and your slash function to
+# restrict access to the "allowed_roles" from the command config by matching it with the function name
+async def role_check(ctx):
+  ctx_type = type(ctx).__name__
+  try:
+    command_config = config["commands"][f"{ctx.command}"]
+    allowed_roles = command_config.get('allowed_roles')
+    if not allowed_roles:
+      return True
+
+    allowed_role_ids = get_role_ids_list(allowed_roles)
+    user_role_ids = [r.id for r in ctx.author.roles]
+
+    allowed = any(user_rid in allowed_role_ids for user_rid in user_role_ids)
+    if not allowed:
+      if ctx_type == 'ApplicationContext':
+        await ctx.respond(f"{get_emoji('guinan_beanflick_stance_threat')} Sorry! You don't have the proper security clearance to use this command.", ephemeral=True)
+    else:
+      return True
+  except Exception as e:
+    logger.info(e)


### PR DESCRIPTION
Since we can't split the permission to pin messages from the ability to delete messages, these two message commands will allow Lt. Commanders (and above?) to do so via Aggy instead.

Also implemented a new `role_check` util for `@commands.check()` so that we can limit command access specifically by roles. You can specify `allowed_roles` in the command config within configuration.json to limit the command to the roles you specify by plain text name. This uses a new counter-part to `generate_local_channel_list()`: `generate_local_role_map()`.

![image](https://user-images.githubusercontent.com/1075211/234941553-238e27a2-5368-4f22-8b4b-636eb1437431.png)


![image](https://user-images.githubusercontent.com/1075211/234941617-7cb387b7-8f66-4d32-a030-ffd5c4659ce2.png)


![image](https://user-images.githubusercontent.com/1075211/234942125-671d4e07-f542-4b23-8940-9a9978909ad2.png)

