### PR TITLE
Migration: Correct "Research/Science" Badge Type

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.24.9
-appVersion: v1.24.9
+version: v1.25.0
+appVersion: v1.25.0

--- a/migrations/v1.25.0.sql
+++ b/migrations/v1.25.0.sql
@@ -1,1 +1,2 @@
 UPDATE badge_type SET type_name = "Science/Research" WHERE type_name = "Research/Science";
+INSERT IGNORE INTO badge_affiliation (badge_filename, affiliation_name) VALUES ("Mikulak.png", "Mikulak");

--- a/migrations/v1.25.0.sql
+++ b/migrations/v1.25.0.sql
@@ -1,0 +1,1 @@
+UPDATE badge_type SET type_name = "Science/Research" WHERE type_name = "Research/Science";


### PR DESCRIPTION
Bad metadata has one badge with a "Research/Science" type while all others are "Science/Research"

Bonus: Fix Mikulak affiliation.

Be sure to run the migration after merging and pulling! 😜