### PR TITLE
Level Up Source: Filter via Starboard Blocked Channels, Add Source for Games/etc

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.26.6
-appVersion: v1.26.6
+version: v1.26.7
+appVersion: v1.26.7

--- a/cogs/chaoszork.py
+++ b/cogs/chaoszork.py
@@ -188,7 +188,7 @@ class DfrotzRunner(commands.Cog):
     if cmd.lower() == 'quit':
       return await self.quit(ctx)
 
-    await increment_user_xp(ctx.author, 1, "played_zork", ctx.channel)
+    await increment_user_xp(ctx.author, 1, "played_zork", ctx.channel, "Playing Zork")
 
     output = self.run_command(cmd)
     if len(output) > 2000:

--- a/cogs/poker.py
+++ b/cogs/poker.py
@@ -203,7 +203,7 @@ class Poker(commands.Cog):
     score_rank = str_score.lower()
     profit = round(poker_payouts[score_rank] * wager)
     if profit != 0:
-      await increment_user_xp(await self.bot.guilds[0].fetch_member(poker_game["user"]), 1, "poker_win", channel)
+      await increment_user_xp(await self.bot.guilds[0].fetch_member(poker_game["user"]), 1, "poker_win", channel, "Winning Poker")
       set_player_score(str(poker_game["user"]), profit)
 
     # Generate Response

--- a/cogs/quiz.py
+++ b/cogs/quiz.py
@@ -143,7 +143,7 @@ class Quiz(commands.Cog):
             award = math.ceil(award / 2)
 
           set_player_score(ctx.author, award)
-          await increment_user_xp(ctx.author, 1, "quiz_win", ctx.channel)
+          await increment_user_xp(ctx.author, 1, "quiz_win", ctx.channel, "Winning a round of Quiz")
 
           if id not in self.fuzz:
             score_str = "`Correctitude: " + str(normalness) +"`"

--- a/cogs/slots.py
+++ b/cogs/slots.py
@@ -164,7 +164,7 @@ class Slots(commands.Cog):
       embed.set_image(url=f"attachment://{player_id}.png")
       embed.set_footer(text=f"{player['name']}'s score: {player['score']+total_profit}")
       set_player_score(ctx.author, total_profit)
-      await increment_user_xp(ctx.author, 1, "slot_win", ctx.channel)
+      await increment_user_xp(ctx.author, 1, "slot_win", ctx.channel, "Winning Slots")
       await ctx.send_followup(embed=embed, file=file, ephemeral=False)
       return
     else:

--- a/cogs/trivia.py
+++ b/cogs/trivia.py
@@ -176,7 +176,7 @@ class Trivia(commands.Cog):
             inline=False
           )
           set_player_score(player, reward)
-          await increment_user_xp(player, xp_reward, "trivia_win", channel)
+          await increment_user_xp(player, xp_reward, "trivia_win", channel, "Winning Trivia")
       if len(incorrect_guessers) > 0:
         for trivia_answer in incorrect_guessers:
           player = trivia_answer['user']
@@ -186,7 +186,7 @@ class Trivia(commands.Cog):
             inline=False
           )
           set_player_score(player, 1)
-          await increment_user_xp(player, 1, "trivia_play", channel)
+          await increment_user_xp(player, 1, "trivia_play", channel, "Participating in Trivia")
       if len(correct_guessers) == 0:
         embed.add_field(name="\nNo winners!", value="Nobody got it this time.", inline=False)
         embed.set_footer(text=f"Adding {reward} point(s) to the jackpot")

--- a/cogs/wordcloud.py
+++ b/cogs/wordcloud.py
@@ -78,7 +78,7 @@ class Wordcloud(commands.Cog):
       await ctx.respond(content="No user data is available for you yet. Post some messages around the server!", ephemeral=True)
       return
     else:
-      await increment_user_xp(ctx.author, 1, "used_wordcloud", ctx.channel)
+      await increment_user_xp(ctx.author, 1, "used_wordcloud", ctx.channel, "Using Wordcloud")
 
     # performing these modifications to the user's data again (in case they have old, uncleaned up data)
     full_wordlist = user_details['full_message_text'].lower().split(' ')

--- a/commands/agimus.py
+++ b/commands/agimus.py
@@ -14,7 +14,7 @@ async def agimus(message:discord.Message):
   if not OPENAI_API_KEY:
     return
 
-  await increment_user_xp(message.author, 1, "asked_agimus", message.channel)
+  await increment_user_xp(message.author, 1, "asked_agimus", message.channel, "Prompting AGIMUS")
   # Message text starts with "AGIMUS:"
   # So split on first : and gather remainder of list into a single string
   question_split = message.content.lower().split(":")

--- a/commands/computer.py
+++ b/commands/computer.py
@@ -31,7 +31,7 @@ async def computer(message:discord.Message):
       res = wa_client.query(question)
       if res.success:
         result = next(res.results)
-        await increment_user_xp(message.author, 1, "used_computer", message.channel)
+        await increment_user_xp(message.author, 1, "used_computer", message.channel, "Prompting the Computer")
         # Handle Primary Result
         if result.text:
           response_sent = await handle_text_result(res, message)

--- a/handlers/starboard.py
+++ b/handlers/starboard.py
@@ -101,7 +101,7 @@ async def add_starboard_post(message, board) -> None:
   if len(message.attachments) <= 0 and message.content.lower().startswith("https://tenor.com/"):
     return
 
-  await increment_user_xp(message.author, 2, "starboard_post", message.channel) # give em that sweet sweet xp first
+  await increment_user_xp(message.author, 2, "starboard_post", message.channel, "Getting a Starboard Post") # give em that sweet sweet xp first
   ALL_STARBOARD_POSTS.append(message.id) # add post ID to in-memory list
   board_channel_id = get_channel_id(board)
   channel = bot.get_channel(board_channel_id) # where it will be posted

--- a/handlers/xp.py
+++ b/handlers/xp.py
@@ -369,7 +369,7 @@ def determine_level_up_source_details(user, source):
   elif isinstance(source, discord.Reaction):
     if is_message_channel_unblocked(source.message):
       if user is source.message.author:
-        return f"Receiving a {get_emoji(source.emoji.name)} react on their message at: {source.message.jump_url}"
+        return f"Receiving a {source.emoji} react on their message at: {source.message.jump_url}"
       else:
         return f"Adding a {source.emoji} react to the message at: {source.message.jump_url}"
   elif isinstance(source, discord.ScheduledEvent):
@@ -385,7 +385,7 @@ def is_message_channel_unblocked(message: discord.message.Message):
     return message.channel.parent.id not in blocked_channels
   if isinstance(message.channel, discord.TextChannel):
     return message.channel.id not in blocked_channels
-  
+
   return False
 
 # get_user_xp(discord_id)


### PR DESCRIPTION
Check against the Starboard's blocked channel list before displaying the level up source (skip entirely if so)

Adding a simple string source for non message/react level ups.

