### PR TITLE
Trade: Provide Send/Cancel UI Immediately After `/trade start`

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.26.15
-appVersion: v1.26.15
+version: v1.26.16
+appVersion: v1.26.16

--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.26.16
-appVersion: v1.26.16
+version: v1.26.17
+appVersion: v1.26.17

--- a/cogs/poker.py
+++ b/cogs/poker.py
@@ -37,7 +37,7 @@ class Poker(commands.Cog):
     if ctx.author.id in self.poker_players:
       await ctx.respond(
         embed=discord.Embed(
-          title=f"{ctx.author.name}: you have a poker game running already! Be patient!",
+          title=f"{ctx.author.display_name}: you have a poker game running already! Be patient!",
           color=discord.Color.red()
         ),
         ephemeral=True

--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -256,7 +256,7 @@ class Profile(commands.Cog):
       base_bg.paste(image, (0, 0), image)
 
     # draw all the texty bits
-    draw.text( (283, 80), f"USS HOOD PERSONNEL FILE #{str(member.id)[-4]}", fill=random.choice(lcars_colors), font=level_font, align="right")
+    draw.text( (283, 80), f"USS HOOD PERSONNEL FILE #{str(member.id)[-4:]}", fill=random.choice(lcars_colors), font=level_font, align="right")
     draw.text( (79, 95), f"AGIMUS MAIN TERMINAL", fill="#dd4444", font=agimus_font, align="center",)
     draw.text( (470, 182), f"{user_name[0:32]}", fill="white", font=name_font, align="center", anchor="ms")
     if user['tagline']:

--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -256,7 +256,7 @@ class Profile(commands.Cog):
       base_bg.paste(image, (0, 0), image)
 
     # draw all the texty bits
-    draw.text( (283, 80), f"USS HOOD PERSONNEL FILE #{member.discriminator}", fill=random.choice(lcars_colors), font=level_font, align="right")
+    draw.text( (283, 80), f"USS HOOD PERSONNEL FILE #{str(member.id)[-4]}", fill=random.choice(lcars_colors), font=level_font, align="right")
     draw.text( (79, 95), f"AGIMUS MAIN TERMINAL", fill="#dd4444", font=agimus_font, align="center",)
     draw.text( (470, 182), f"{user_name[0:32]}", fill="white", font=name_font, align="center", anchor="ms")
     if user['tagline']:

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -763,16 +763,20 @@ class Trade(commands.Cog):
       else:
         db_add_badge_to_trade_request(active_trade, request)
 
+
+    initiated_trade = await self.check_for_active_trade(ctx)
+
     # Confirmation of initiation with the requestor
     if not offer and not request:
       follow_up_message = "Follow up with `/trade propose` to fill out the trade details!"
     else:
       follow_up_message = "You can add more badges with with `/trade propose`, or you can **Send** / **Cancel** the trade immediately via the buttons below."
 
+    # Paginator Pages
     initiated_embed = discord.Embed(
       title="Trade Started!",
-      description=f"Your pending trade has been started!\n\n{follow_up_message}\n\nOnce you have added the badges "
-                  "you'd like to offer and request, use \n`/trade send` to send the trade to the user, "
+      description=f"Your pending trade has been started!\n\n{follow_up_message}\n\nIf you have additional badges "
+                  "you need to offer and request, use \n`/trade send` afterwards to send the trade to the user, "
                   "or to cancel!\n\nNote: You may only have one open outgoing trade request at a time!",
       color=discord.Color.dark_purple()
     ).add_field(
@@ -784,15 +788,18 @@ class Trade(commands.Cog):
     )
     initiated_embed.set_footer(text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}")
 
-    # Paginator Pages
+    initiated_image = discord.File(fp="./images/trades/assets/trade_pending.png", filename="trade_pending.png")
+    initiated_embed.set_image(url=f"attachment://trade_pending.png")
+
     initiated_pages = [
       pages.Page(
-        embeds=[initiated_embed]
+        embeds=[initiated_embed],
+        files=[initiated_image]
       )
     ]
 
     # Offered page
-    offered_embed, offered_image = await self._generate_offered_embed_and_image(active_trade)
+    offered_embed, offered_image = await self._generate_offered_embed_and_image(initiated_trade)
     initiated_pages.append(
       pages.Page(
         embeds=[offered_embed],
@@ -801,7 +808,7 @@ class Trade(commands.Cog):
     )
 
     # Requested Page
-    requested_embed, requested_image = await self._generate_requested_embed_and_image(active_trade)
+    requested_embed, requested_image = await self._generate_requested_embed_and_image(initiated_trade)
     initiated_pages.append(
       pages.Page(
         embeds=[requested_embed],
@@ -810,7 +817,7 @@ class Trade(commands.Cog):
     )
 
     # Provide Send/Cancel UI immediately
-    view = SendCancelView(self, active_trade)
+    view = SendCancelView(self, initiated_trade)
     paginator = pages.Paginator(
       pages=initiated_pages,
       use_default_buttons=False,

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -770,7 +770,7 @@ class Trade(commands.Cog):
     if not offer and not request:
       follow_up_message = "Follow up with `/trade propose` to fill out the trade details!"
     else:
-      follow_up_message = "You can add more badges with with `/trade propose`, or you can **Send** / **Cancel** the trade immediately via the buttons below."
+      follow_up_message = "You can add more badges with `/trade propose`, or you can **Send** / **Cancel** the trade immediately via the buttons below."
 
     # Paginator Pages
     initiated_embed = discord.Embed(

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -779,7 +779,7 @@ class Trade(commands.Cog):
       name="Badges offered by you",
       value=offer
     ).add_field(
-      name=f"Badges requested from {requestee.name}",
+      name=f"Badges requested from {requestee.display_name}",
       value=request
     )
     initiated_embed.set_footer(text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}")

--- a/cogs/wishlist.py
+++ b/cogs/wishlist.py
@@ -79,7 +79,7 @@ class DismissButton(discord.ui.Button):
     self.has = json.dumps(has)
     self.wants = json.dumps(wants)
     super().__init__(
-      label="    Dismiss    ",
+      label="    Dismiss Match    ",
       style=discord.ButtonStyle.primary,
       row=2
     )

--- a/data/clips.json
+++ b/data/clips.json
@@ -69,6 +69,11 @@
     "description": "My dear doctor they're all true, even the lies, especially the lies",
     "url": "https://i.imgur.com/KayZHFN.mp4"
   },
+  "Geordi - Leak? I'm not detecting any leak?": {
+    "file": "data/clips/geordinotdetectinganyleak.mp4",
+    "description": "Geordi leak I'm not detecting any leak",
+    "url": "https://i.imgur.com/MngSWdu.mp4"
+  },
   "Kevin - All Husnock Everywhere!": {
     "file": "data/clips/kevinallhusnockeverywhere.mp4",
     "description": "Kevin Uxbridge killed them all, all husnock everywhere",

--- a/data/drops.json
+++ b/data/drops.json
@@ -219,6 +219,11 @@
     "description": "He Just Kept Talking In One Long Incredibly Unbroken Sentence",
     "url": "https://i.imgur.com/e9CY7Nu.mp4"
   },
+  "He Was A Union Man!": {
+    "file": "data/drops/hewasaunionman.mp4",
+    "description": "O'Brien He Was More Than A Hero He Was A Union Man",
+    "url": "https://i.imgur.com/ttZLeAY.mp4"
+  },
   "Hell Of A Combination": {
     "file": "data/drops/hellofacombination.mp4",
     "description": "Rambo II: That's a hell of a combination!",
@@ -733,6 +738,11 @@
     "file": "data/drops/thevulpesiadrop.mp4",
     "description": "The Vulpesia Drop. User drop.",
     "url": "https://i.imgur.com/sNZaGdb.mp4"
+  },
+  "The Worf Drop": {
+    "file": "data/drops/theworfdrop.mp4",
+    "description": "The Worf Drop A Warrior Must Be Forged Like A Sword The Path Of The Warrior",
+    "url": "https://i.imgur.com/Nv9FGP4.mp4"
   },
   "The Worf's Calisthenics Drop": {
     "file": "data/drops/theworfscalisthenicsdrop.mp4",


### PR DESCRIPTION
Now provides a paginator and view similar to `/trade send` immediately after you use `/trade start`:

![image](https://github.com/jp00p/AGIMUS/assets/1075211/6e038c30-7680-4817-8496-df0e69815b61)

Couple other misc bundled tweaks/etc as well.

* Couple corrections to use a user's `.display_name` rather than `.name`
* `/profile display` now uses the last four digits of the user's discord id rather than the now defunct discriminator
* One new clip and two new drops
* Wording change on wishlist dismissal to differentiate it as dismissing the match rather than the message itself