### PR TITLE
Attach Spoilered Images To Starboard Posts

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.26.19
-appVersion: v1.26.19
+version: v1.26.20
+appVersion: v1.26.20

--- a/handlers/starboard.py
+++ b/handlers/starboard.py
@@ -187,7 +187,7 @@ async def add_starboard_post(message, board) -> None:
       if attachment.is_spoiler():
         spoiler_file = await attachment.to_file(spoiler=True)
       elif attachment.content_type.startswith("image"):
-        star_embed.set_image(attachment.proxy_url)
+        star_embed.set_image(url=attachment.proxy_url)
 
   if embed_thumb != "":
     star_embed.set_thumbnail(url=embed_thumb)

--- a/handlers/xp.py
+++ b/handlers/xp.py
@@ -376,6 +376,8 @@ def determine_level_up_source_details(user, source):
     return f"Scheduing the `{source.name}` event"
   elif isinstance(source, str):
     return source
+  else:
+    return random.choice([ "Personal Log", "Code 47", "Classified" ])
 
 def is_message_channel_unblocked(message: discord.message.Message):
   # Use starboard blocked channel list to verify whether we should be reporting the source

--- a/handlers/xp.py
+++ b/handlers/xp.py
@@ -377,7 +377,7 @@ def determine_level_up_source_details(user, source):
   elif isinstance(source, str):
     return source
   else:
-    return random.choice([ "Personal Log", "Code 47", "Classified" ])
+    return random.choice([ "Personal Log", "Code 47", "Classified by Section 31" ])
 
 def is_message_channel_unblocked(message: discord.message.Message):
   # Use starboard blocked channel list to verify whether we should be reporting the source


### PR DESCRIPTION
Currently if someone gets a starboard post that has a spoilered attachment we're embedding it directly via the proxy_url which might be an issue if there are episode spoilers that get some laughs, heart, eat, pray, love, etc. cause it'll just show up directly in the starboard channel.

This checks if an attachment is spoilered and will reattach it to the starboard message instead with the spoiler flag.

![image](https://github.com/jp00p/AGIMUS/assets/1075211/b03cc232-183b-405b-b24b-b2086d5f6a91)

Also added a few default messages for the XP level up source if one isn't returned due to the interaction ocurring in a restricted channel, etc.