### PR TITLE
Fix For Dabo Selection

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.29.0
-appVersion: v1.29.0
+version: v1.29.1
+appVersion: v1.29.1

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -831,8 +831,8 @@ class Trade(commands.Cog):
     requestee_unlocked_badges = [b['badge_name'] for b in db_get_user_unlocked_badges(requestee_id)]
 
     # Get only the badges to offer/request that are not already present in the other user's inventory yet
-    valid_requestor_badges = np.setdiff1d(requestor_unlocked_badges, requestee_total_badges)
-    valid_requestee_badges = np.setdiff1d(requestee_unlocked_badges, requestor_total_badges)
+    valid_requestor_badges = list(np.setdiff1d(requestor_unlocked_badges, requestee_total_badges))
+    valid_requestee_badges = list(np.setdiff1d(requestee_unlocked_badges, requestor_total_badges))
 
     # Check to make sure both parties have enough
     if len(valid_requestor_badges) < amount or len(valid_requestee_badges) < amount:


### PR DESCRIPTION
Derp. Needed to make sure that the badges that we're selecting for the dabo trades don't contain any that the other user may _already have_.

This ought to do it.