### PR TITLE
Send Notifications on Dabo Wishlist Acquisitions

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.29.1
-appVersion: v1.29.1
+version: v1.29.2
+appVersion: v1.29.2

--- a/cogs/slots.py
+++ b/cogs/slots.py
@@ -1,5 +1,8 @@
 import math
 import time
+from pytz import timezone
+import pytz
+
 from common import *
 from handlers.xp import increment_user_xp
 from utils.check_channel_access import access_check
@@ -369,8 +372,16 @@ class Slots(commands.Cog):
       winner_str = (winner[:24] + '...') if len(winner) > 24 else winner
       winners.append(winner_str)
 
-      lifespan = jackpot["time_won"] - jackpot["time_created"]
-      lifespan_str = humanize.naturaltime(datetime.now() - jackpot['time_created'])
+      pst_tz = timezone('US/Pacific')
+      raw_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+      raw_time_won = pytz.utc.localize(jackpot["time_won"])
+      raw_time_created = pytz.utc.localize(jackpot["time_created"])
+      aware_now = pst_tz.normalize(raw_now.astimezone(pst_tz))
+      aware_time_won = pst_tz.normalize(raw_time_won.astimezone(pst_tz))
+      aware_time_created = pst_tz.normalize(raw_time_created.astimezone(pst_tz))
+
+      lifespan = aware_time_won - aware_time_created
+      lifespan_str = humanize.naturaltime(aware_now - aware_time_created)
       lifespan_str += f" ({lifespan.days}d {lifespan.seconds // 3600}h {(lifespan.seconds // 60) % 60}m)"
       lifespans.append(lifespan_str)
 

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -399,7 +399,7 @@ class Trade(commands.Cog):
             )
             wishlist_success_embed.add_field(
               name="Wishlisted Acquisitions",
-              value=[f"* {b}" for b in requestor_wishlist_successes],
+              value="\n".join([f"* {b}" for b in requestor_wishlist_successes]),
               inline=False
             )
             wishlist_success_embed.set_footer(
@@ -425,7 +425,7 @@ class Trade(commands.Cog):
           )
           wishlist_success_embed.add_field(
             name="Wishlisted Acquisitions",
-            value=[f"* {b}" for b in requestee_wishlist_successes],
+            value="\n".join([f"* {b}" for b in requestee_wishlist_successes]),
             inline=False
           )
           wishlist_success_embed.set_footer(

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -1,5 +1,5 @@
 from common import *
-from queries.wishlist import db_autolock_badges_by_filenames_if_in_wishlist
+from queries.wishlist import db_autolock_badges_by_filenames_if_in_wishlist, db_get_user_wishlist_badges
 from utils.badge_utils import *
 from utils.check_channel_access import access_check
 
@@ -325,10 +325,14 @@ class Trade(commands.Cog):
     db_complete_trade(active_trade)
 
     # Lock badges the users now possess that were in their wishlists
-    requested_badge_filenames = [b['badge_filename'] for b in db_get_trade_requested_badges(active_trade)]
-    db_autolock_badges_by_filenames_if_in_wishlist(requestor.id, requested_badge_filenames)
-    offered_badge_filenames = [b['badge_filename'] for b in db_get_trade_offered_badges(active_trade)]
-    db_autolock_badges_by_filenames_if_in_wishlist(requestee.id, offered_badge_filenames)
+    # Stash the wishlist badges prior to purging to alert users in Dabo matches if they've acquired a Wishlist item
+    requestors_previous_wishlist_badges = db_get_user_wishlist_badges(requestor.id)
+    requested_badges = db_get_trade_requested_badges(active_trade)
+    db_autolock_badges_by_filenames_if_in_wishlist(requestor.id, [b['badge_filename'] for b in requested_badges])
+
+    requestees_previous_wishlist_badges = db_get_user_wishlist_badges(requestee.id)
+    offered_badges = db_get_trade_offered_badges(active_trade)
+    db_autolock_badges_by_filenames_if_in_wishlist(requestee.id, [b['badge_filename'] for b in offered_badges])
 
     # Delete Badges From Users Wishlists
     db_purge_users_wishlist(requestor.id)
@@ -364,9 +368,9 @@ class Trade(commands.Cog):
     channel = interaction.channel
     message = await channel.send(embed=success_embed, file=success_image)
 
-    # Send notification to requestor the the trade was successful
-    user = get_user(requestor.id)
-    if user["receive_notifications"]:
+    # Send notification to requestor that the trade was successful
+    requestor_user = get_user(requestor.id)
+    if requestor_user["receive_notifications"]:
       try:
         success_embed.add_field(
           name="View Confirmation",
@@ -378,8 +382,59 @@ class Trade(commands.Cog):
         )
         await requestor.send(embed=success_embed)
       except discord.Forbidden as e:
-        logger.info(f"Unable to send trade cancelation message to {requestor.display_name}, they have their DMs closed.")
+        logger.info(f"Unable to send trade confirmation message to {requestor.display_name}, they have their DMs closed.")
         pass
+
+       # Send notification to requestor if they completed a Dabo Trade and got some Wishlist badges
+      if active_trade["type"] == 'dabo':
+        requestor_wishlisted_badge_names = [b['badge_name'] for b in requestors_previous_wishlist_badges]
+        requestor_acquired_badge_names = [b['badge_name'] for b in requested_badges]
+        requestor_wishlist_successes = [b for b in requestor_acquired_badge_names if b in requestor_wishlisted_badge_names]
+        if len(requestor_wishlist_successes):
+          try:
+            wishlist_success_embed = discord.Embed(
+              title="You got some Wishlisted Badges from that Dabo Trade!",
+              description=f"Hey just a heads up, one or more of the badges you received from your recent Dabo Trade with **{requestee.display_name}** were on your wishlist! Noice.",
+              color=discord.Color.dark_purple()
+            )
+            wishlist_success_embed.add_field(
+              name="Wishlisted Acquisitions",
+              value=[f"* {b}" for b in requestor_wishlist_successes],
+              inline=False
+            )
+            wishlist_success_embed.set_footer(
+              text="Note: You can use /settings to enable or disable these messages."
+            )
+            await requestor.send(embed=wishlist_success_embed)
+          except discord.Forbidden as e:
+            logger.info(f"Unable to send Wishlist Acquisition message to {requestor.display_name}, they have their DMs closed.")
+            pass
+
+    # Send notification to requestee if they completed a Dabo Trade and got some Wishlist badges
+    requestee_user = get_user(requestee.id)
+    if requestee_user["receive_notifications"] and active_trade["type"] == 'dabo':
+      requestee_wishlisted_badge_names = [b['badge_name'] for b in requestees_previous_wishlist_badges]
+      requestee_acquired_badge_names = [b['badge_name'] for b in offered_badges]
+      requestee_wishlist_successes = [b for b in requestee_acquired_badge_names if b in requestee_wishlisted_badge_names]
+      if len(requestee_wishlist_successes):
+        try:
+          wishlist_success_embed = discord.Embed(
+            title="You got Wishlisted Badges from that Dabo Trade!",
+            description=f"Hey just a heads up, one or more of the badges you received from your recent Dabo Trade with **{requestor.display_name}** were on your wishlist! Noice.",
+            color=discord.Color.dark_purple()
+          )
+          wishlist_success_embed.add_field(
+            name="Wishlisted Acquisitions",
+            value=[f"* {b}" for b in requestee_wishlist_successes],
+            inline=False
+          )
+          wishlist_success_embed.set_footer(
+            text="Note: You can use /settings to enable or disable these messages."
+          )
+          await requestee.send(embed=wishlist_success_embed)
+        except discord.Forbidden as e:
+          logger.info(f"Unable to send Wishlist Acquisition message to {requestee.display_name}, they have their DMs closed.")
+          pass
 
 
   async def _cancel_invalid_related_trades(self, active_trade):

--- a/commands/gifbomb.py
+++ b/commands/gifbomb.py
@@ -1,0 +1,44 @@
+import aiohttp
+from common import *
+from utils.check_role_access import role_check
+
+@bot.slash_command(
+  name="gifbomb",
+  description="Send the Top 5 Gifs for your query to the channel"
+)
+@option(
+  "query",
+  str,
+  description="Gif Search",
+  required=True
+)
+@commands.check(role_check)
+async def aliases(ctx:discord.ApplicationContext, query:str):
+  await ctx.defer(ephemeral=True)
+  channel = ctx.interaction.channel
+
+  async with aiohttp.ClientSession() as session:
+    key = os.getenv('GOOGLE_API_KEY')
+    async with session.get(
+      "https://tenor.googleapis.com/v2/search?q=%s&key=%s&client_key=%s&limit=5&contentfilter=medium" % (query, key)
+    ) as response:
+      if response.status == 200:
+        await ctx.respond(embed=discord.Embed(
+            title="GIF BOMB!",
+            color=discord.color.blurple()
+          ), ephemeral=False
+        )
+        data = json.loads(await response.text())
+        results = data['results']
+        for i in results:
+          embed = discord.Embed(color=discord.Color.random())
+          embed.set_image(results[i]['gif']['url'])
+          embed.set_footer(text="via Tenor")
+          await channel.send(embed=embed)
+      else:
+        await ctx.respond(embed=discord.Embed(
+            title="Whoops",
+            description="There was a problem requesting the Gifs from Tenor!",
+            color=discord.color.red()
+          ), ephemeral=True
+        )

--- a/configuration.json
+++ b/configuration.json
@@ -452,6 +452,17 @@
         "Lt. Commander",
         "Lieutenant"
       ],
+      "blocked_channels": [
+        "neelixs-morale-office",
+        "plasma-vent",
+        "counselor-trois-office",
+        "peoples-resistance-front-of-bajor",
+        "heuristic-associative-pathways",
+        "behind-the-visor",
+        "garaks-tailor-shop",
+        "the-next-next-generation",
+        "sicks-bay"
+      ],
       "enabled": true,
       "data": null,
       "parameters": []

--- a/configuration.json
+++ b/configuration.json
@@ -444,6 +444,18 @@
       "data": "data/all_characters.txt",
       "parameters": []
     },
+    "gifbomb": {
+      "allowed_roles": [
+        "Admiral",
+        "Captain",
+        "Commander",
+        "Lt. Commander",
+        "Lieutenant"
+      ],
+      "enabled": true,
+      "data": null,
+      "parameters": []
+    },
     "help": {
       "enabled": true,
       "data": "data/help.json",

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from commands.aliases import aliases
 from commands.badges import *
 from commands.dustbuster import dustbuster
 from commands.fmk import fmk
+from commands.gifbomb import gifbomb
 from commands.help import help
 from commands.info import info
 from commands.levelcheck import levelcheck


### PR DESCRIPTION
# Dabo Wishlist Notifications
If either party receives an item from the randomized trade that was one on their wishlist, AGIMUS will now send them a DM to let them know.

I set this only for Dabo trades because I figure 99% of trades outside of Dabo these days are done by direct Wishlist match, so it would be kind of redundant.

# Also, `/gifbomb`

# Also, I may or may not have either fixed or broken `/slots jackpots`