### PR TITLE
Fixes For Wishlist Timeouts, Misc Timestamps, and Correct Channel for Server Logs

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.29.2
-appVersion: v1.29.2
+version: v1.29.3
+appVersion: v1.29.3

--- a/cogs/slots.py
+++ b/cogs/slots.py
@@ -1,6 +1,5 @@
 import math
 import time
-from pytz import timezone
 import pytz
 
 from common import *
@@ -41,8 +40,8 @@ class Slots(commands.Cog):
   async def spin(self, ctx:discord.ApplicationContext, show:str):
     await ctx.defer(ephemeral=True)
 
-    logger.info(f"{Style.BRIGHT}{ctx.author.name}{Style.RESET_ALL} is {Fore.LIGHTYELLOW_EX}rolling the slots!{Fore.RESET}")   
-    
+    logger.info(f"{Style.BRIGHT}{ctx.author.name}{Style.RESET_ALL} is {Fore.LIGHTYELLOW_EX}rolling the slots!{Fore.RESET}")
+
     # Load slots data
     f = open(command_config["data"])
     SLOTS = json.load(f)
@@ -51,20 +50,20 @@ class Slots(commands.Cog):
     # Use the option the user selected or pick a random show
     if show not in command_config["parameters"][0]["allowed"]:
       show = random.choice(["TNG", "DS9", "VOY", "HOLODECK", "SHIPS"])
-    
+
     #logger.info(f"{Fore.LIGHTRED_EX}Rolling slot theme:{Fore.RESET} {Style.BRIGHT}{show}{Style.RESET_ALL}")
-    # player data  
+    # player data
     player_id = ctx.author.id
     player = get_user(player_id)
     free_spin = player["spins"] < 5 # true or false
     wager = player["wager"]
     score_mult = wager
-    
+
     # if they have less than 5 total spins, give em a free one
     if free_spin:
       wager = 0
       score_mult = 1
-    
+
     total_rewards = 0
     themed_payout = SLOTS[show]["payout"]
     #logger.info("payout" + str(themed_payout))
@@ -78,25 +77,25 @@ class Slots(commands.Cog):
       return
 
     spinnin = [
-      "All I do is *slots slots slots*!", 
-      "Time to pluck a pigeon!", 
-      "Rollin' with my homies...", 
-      "It's time to spin!", 
-      "Let's roll.", 
-      "ROLL OUT!", 
-      "Get it player.", 
-      "Go go gadget slots!", 
-      "Activating slot subroutines!", 
+      "All I do is *slots slots slots*!",
+      "Time to pluck a pigeon!",
+      "Rollin' with my homies...",
+      "It's time to spin!",
+      "Let's roll.",
+      "ROLL OUT!",
+      "Get it player.",
+      "Go go gadget slots!",
+      "Activating slot subroutines!",
       "Reversing polarity on Alpha-probability particle emitters.",
-    ] 
-    
-    # build the spin embed (spinbed)    
+    ]
+
+    # build the spin embed (spinbed)
     spin_msg = ""
-   
+
     if free_spin:
       spin_msg += "**This one's on the house!** (after 5 free spins, they will cost you points!)"
     else:
-      spin_msg += f"Spending `{wager}` of your points!"    
+      spin_msg += f"Spending `{wager}` of your points!"
 
     spinbed = discord.Embed(
       title=random.choice(spinnin),
@@ -104,7 +103,7 @@ class Slots(commands.Cog):
       color=discord.Color.random()
     )
     spinbed.set_footer(text=f"This is spin #{player['spins']+1} for you.")
-    await ctx.send_followup(embed=spinbed, ephemeral=False) # first followup 
+    await ctx.send_followup(embed=spinbed, ephemeral=False) # first followup
 
     # roll the slots!
     silly_matches, matching_chars, jackpot, symbol_matches = self.roll_slot(show, SLOTS[show], filename=str(player_id))
@@ -129,7 +128,7 @@ class Slots(commands.Cog):
       match_msg += f" `{len(silly_matches) * score_mult} point(s)`\n"
       total_rewards += len(silly_matches) * score_mult
 
-    # matching characters (transporter clones)  
+    # matching characters (transporter clones)
     if len(matching_chars) > 0:
       match_msg += "**Transporter clones: ** "
       match_msg += ", ".join(matching_chars).replace("_", " ").title()
@@ -148,7 +147,7 @@ class Slots(commands.Cog):
       win_jackpot(ctx.author.display_name, player_id)
       jackpot_embed = discord.Embed(
         title=f"**{ctx.author.display_name} WINS THE JACKPOT!!!**".upper(),
-        color=embed_color        
+        color=embed_color
       )
       jackpot_embed.set_image(url="https://i.imgur.com/S7Pv9lM.jpg")
       await ctx.send_followup(embed=jackpot_embed, ephemeral=False)
@@ -372,7 +371,7 @@ class Slots(commands.Cog):
       winner_str = (winner[:24] + '...') if len(winner) > 24 else winner
       winners.append(winner_str)
 
-      pst_tz = timezone('US/Pacific')
+      pst_tz = pytz.timezone('America/Los_Angeles')
       raw_now = datetime.utcnow().replace(tzinfo=pytz.utc)
       raw_time_won = pytz.utc.localize(jackpot["time_won"])
       raw_time_created = pytz.utc.localize(jackpot["time_created"])
@@ -462,7 +461,7 @@ class Slots(commands.Cog):
           if jackpot:
             jackpots += 1
           profits.append(profit)
-          
+
         chance_to_win = (wins/spins)*100
         chance_to_jackpot = (jackpots/spins)*100
         chance_for_profit = (profitable_wins/spins)*100
@@ -476,6 +475,6 @@ class Slots(commands.Cog):
       else:
         await ctx.send("Ah ah ah, you didn't say the magic word", ephemeral=True)
     except BaseException as e:
-      logger.info(traceback.format_exc())   
+      logger.info(traceback.format_exc())
 
-      
+

--- a/commands/aliases.py
+++ b/commands/aliases.py
@@ -1,6 +1,5 @@
 from common import *
 from utils.check_channel_access import access_check
-from pytz import timezone
 import pytz
 
 @bot.slash_command(
@@ -27,7 +26,7 @@ async def aliases(ctx:discord.ApplicationContext, user:discord.User):
   old_aliases = "\n".join([a['old_alias'] for a in aliases])
   new_aliases = "\n".join([a['new_alias'] for a in aliases])
 
-  pst_tz = timezone('US/Pacific')
+  pst_tz = pytz.timezone('America/Los_Angeles')
 
   raw_timestamps = [pytz.utc.localize(a['time_created']) for a in aliases]
   aware_timestamps = [pst_tz.normalize(t.astimezone(pst_tz)) for t in raw_timestamps]

--- a/configuration.json
+++ b/configuration.json
@@ -1000,7 +1000,7 @@
     "**{}** took a promotion to the Titan",
     "**{}** was last seen on the way to Wolf 359",
     "**{}** escaped the confines of the holodeck",
-    "**{}** got stuck in a causality loop\n**{}** got stuck in a causality loop\n**{}** got stuck in a causality loop\n**{}** got stuck in a causality loop\n",
+    "**{0}** got stuck in a causality loop\n**{0}** got stuck in a causality loop\n**{0}** got stuck in a causality loop\n**{0}** got stuck in a causality loop\n",
     "**{}** got Spock Boxed",
     "**{}** went all *\"needs of the many\"* on us",
     "**{}** lost molecular cohesion",

--- a/handlers/server_logs.py
+++ b/handlers/server_logs.py
@@ -1,4 +1,4 @@
-from datetime import date
+import pytz
 from common import *
 
 
@@ -8,20 +8,26 @@ from common import *
 async def show_leave_message(member:discord.Member):
   if member.bot:
     return
-  server_log_channel = bot.get_channel(SERVER_LOGS_CHANNEL)
+  server_logs_channel = bot.get_channel(get_channel_id(config["server_logs_channel"]))
   name = member.display_name
   msg = "__" + random.choice(config["leave_messages"]).format(name) + "__ 😞"
   weather = random.choice(["gloomy", "rainy", "foggy", "chilly", "quiet", "soggy", "misty", "stormy"])
-  join_date = member.joined_at
-  time_diff = datetime.now(timezone.utc) - join_date
+
+  pst_tz = pytz.timezone('America/Los_Angeles')
+  raw_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+  aware_now = pst_tz.normalize(raw_now.astimezone(pst_tz))
+  join_date = pst_tz.normalize(member.joined_at.astimezone(pst_tz)) # Member.joined_at is already UTC aware
+
+  time_diff = aware_now - join_date
   seconds = time_diff.days * 24 * 3600  + time_diff.seconds
   minutes, seconds = divmod(seconds, 60)
   hours, minutes = divmod(minutes, 60)
   days, hours = divmod(hours, 24)
   membership_length = f"{days} days, {hours} hours, {minutes} minutes, {seconds} seconds"
+
   msg += "\n> **Join date:** {} (a {} {})\n> **Member for:** {}\n".format(join_date.strftime("%B %d, %Y"), weather, join_date.strftime("%A"), membership_length)
   logger.info(f"{Fore.LIGHTRED_EX}{name} has left the server! :({Fore.RESET}")
-  await server_log_channel.send(msg)
+  await server_logs_channel.send(msg)
 
 # show_nick_change_message(before,after)
 # shows a message when someone changes their nickname on the server
@@ -49,19 +55,19 @@ async def show_nick_change_message(before, after, scope = ""):
 # sends a message when someone creates a new channel on the server
 # channel[required]: discord.Channel
 async def show_channel_creation_message(channel):
-  server_log_channel = bot.get_channel(SERVER_LOGS_CHANNEL)
+  server_logs_channel = bot.get_channel(get_channel_id(config["server_logs_channel"]))
   msg = f"✨ A new channel, **'#{channel.name}'**, was just created!"
   logger.info(f"{Fore.LIGHTGREEN_EX}#{channel.name}{Fore.RESET} was just created")
-  await server_log_channel.send(msg)
+  await server_logs_channel.send(msg)
 
 # show_channel_deletion_message(channel)
 # sends a message when someone deletes a channel on the server
 # channel[required]: discord.Channel
 async def show_channel_deletion_message(channel):
-  server_log_channel = bot.get_channel(SERVER_LOGS_CHANNEL)
+  server_logs_channel = bot.get_channel(get_channel_id(config["server_logs_channel"]))
   msg = f"💥 **'#{channel.name}'**, was just deleted!"
   logger.info(f"{Fore.LIGHTGREEN_EX}#{channel.name}{Fore.RESET} was just deleted")
-  await server_log_channel.send(msg)
+  await server_logs_channel.send(msg)
 
 # show_channel_rename_message(channel)
 # sends a message when someone renames a channel on the server
@@ -71,10 +77,10 @@ async def show_channel_rename_message(before, after):
   if before.name == after.name:
     return
 
-  server_log_channel = bot.get_channel(SERVER_LOGS_CHANNEL)
+  server_logs_channel = bot.get_channel(get_channel_id(config["server_logs_channel"]))
   msg = f"↪️ **'#{before.name}'** was renamed to **'#{after.name}'**!"
   logger.info(f"{Fore.LIGHTGREEN_EX}#{before.name}{Fore.RESET} was just renamed to {Fore.LIGHTGREEN_EX}#{after.name}{Fore.RESET}")
-  await server_log_channel.send(msg)
+  await server_logs_channel.send(msg)
 
 # show_channel_topic_change_message(channel)
 # sends a message when someone changes the topic of a channel on the server
@@ -84,7 +90,7 @@ async def show_channel_topic_change_message(before, after):
   if before.topic == after.topic:
     return
 
-  server_log_channel = bot.get_channel(SERVER_LOGS_CHANNEL)
+  server_logs_channel = bot.get_channel(get_channel_id(config["server_logs_channel"]))
   msg = f"✏️ Topic in {after.mention} was updated to:\n\n> {after.topic}"
   logger.info(f"Topic in {Fore.LIGHTGREEN_EX}#{after.name}{Fore.RESET} updated")
-  await server_log_channel.send(msg)
+  await server_logs_channel.send(msg)


### PR DESCRIPTION
## Address Wishlist Timeouts

This hopefully addresses problems that have been cropping up with `/wishlist matches` and `/wishlist dismissals`:

![image](https://github.com/jp00p/AGIMUS/assets/1075211/6bc03655-808a-4807-9c6f-abde0d3242e7)

Seems to have been caused with some changes in the latest pycord version in how interaction messages are stashed, so trying to delete the original message on the Dismissal and Revoke button callbacks was causing 404s since it couldn't locate them.

So, now we're opting to use the new `interaction.edit()` convenience method to just replace the contents of the message the button was attached to with the success message rather than previously where we were deleting the existing message and creating a whole new message response.

### Subclassing `pages.Paginator`'s `on_timeout` method

There's an open issue where if an original paginator message is dismissed (if it was ephemeral) or otherwise edited/deleted, when the `on_timeout` method is kicked off to disable the paginator's UI elements, it also encounters a 404 because the original message is no longer present. Per a help thread on the pycord discord server, I'm just wrapping the `on_timeout` in an except/pass for the time being, it sounds like they'll be adding a parameter to address this in an upcoming release.

## Force Timestamps to use UTC -> Pacific Timezone Info
I feel like this is verbose but it's what I've come up with to try to ensure that the timestamps for `/slots jackpots`, `/aliases`, and `show_leave_message()` report durations/etc in a mostly sane way(!?!) 🤷 

## Use `config["server_logs_channel"]` in `handlers/server_logs.py`
Looks like we were relying on a global variable which doesn't seem to be present here anymore, so explicitly loading the config option to send these messages again (#captains-log)