### PR TITLE
LIMIT the Number of Wishlist Dismissals to Retrieve

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.29.3
-appVersion: v1.29.3
+version: v1.29.4
+appVersion: v1.29.4

--- a/queries/wishlist.py
+++ b/queries/wishlist.py
@@ -207,7 +207,7 @@ def db_get_wishlist_inventory_matches(user_discord_id):
 def db_get_wishlist_dismissal(user_discord_id, match_discord_id):
   with AgimusDB(dictionary=True) as query:
     sql = '''
-      SELECT * FROM wishlist_dismissals WHERE user_discord_id = %s AND match_discord_id = %s;
+      SELECT * FROM wishlist_dismissals WHERE user_discord_id = %s AND match_discord_id = %s LIMIT 1;
     '''
     vals = (user_discord_id, match_discord_id)
     query.execute(sql, vals)


### PR DESCRIPTION
We got into a funky state with some broken Wishlist Dismissal and Revoke buttons recently, see: #453 

This apparently created some duplicate rows in the `wishlist_dismissals` table, which the `fetchone()` call wasn't happy with because it was returning unread results.

Add a `LIMIT 1` to the lookup and the rest should sort itself out when they perform the next `/wishlist matches` and get cleared out by `db_delete_wishlist_dismissal()` on mismatch.