### PR TITLE
`/tag carousel`

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.29.4
-appVersion: v1.29.4
+version: v1.29.5
+appVersion: v1.29.5

--- a/cogs/badge_tags.py
+++ b/cogs/badge_tags.py
@@ -65,7 +65,7 @@ class TagButton(discord.ui.Button):
     self.user_discord_id = user_discord_id
     self.badge_name = badge_name
     super().__init__(
-      label="           Tag Badge           ",
+      label="Tag Badge",
       style=discord.ButtonStyle.primary,
       row=2
     )
@@ -84,7 +84,7 @@ class TagButton(discord.ui.Button):
     if len(new_associated_tag_names):
       description = f"**{self.badge_name}** is now tagged with:" + "\n\n- " + "\n- ".join(new_associated_tag_names) + "\n\n" + "Use `/tags showcase` to show off your tags!"
     else:
-      description = f"**{self.badge_name}** no longer has any tags associated!"
+      description = f"**{self.badge_name}** currently has no tags associated!"
 
     await interaction.response.edit_message(
       embed=discord.Embed(
@@ -102,7 +102,7 @@ class CarouselButton(discord.ui.Button):
     self.user_discord_id = user_discord_id
     self.badge_name = badge_name
     super().__init__(
-      label="           Tag Badge           ",
+      label="Tag Badge / Move On",
       style=discord.ButtonStyle.primary,
       row=2
     )
@@ -122,11 +122,11 @@ class CarouselButton(discord.ui.Button):
     if len(new_associated_tag_names):
       description = f"**{self.badge_name}** is now tagged with:" + "\n\n- " + "\n- ".join(new_associated_tag_names) + "\n\n" + "Use `/tags showcase` to show off your tags!"
     else:
-      description = f"**{self.badge_name}** no longer has any tags associated!"
+      description = f"**{self.badge_name}** currently has no tags associated!"
 
     await interaction.edit(
       embed=discord.Embed(
-        title="Tags Updated",
+        title="Tag Summary",
         description=description,
         color=discord.Color.green()
       ),


### PR DESCRIPTION
Had an idea where users can fire off a `/tag carousel` and the system will present them with a random badge that they can tag. Once they've tagged it (or untagged it), it then presents them with another new random badge, and so on and so on.

Should provide a cheap and easy way if people want to kinda walk through their existing inventory and apply some tags that might be missing, etc.