### PR TITLE
Stop `/tags carousel` When User Has Depleted All Possible Badges

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.29.5
-appVersion: v1.29.5
+version: v1.29.6
+appVersion: v1.29.6

--- a/cogs/badge_tags.py
+++ b/cogs/badge_tags.py
@@ -137,6 +137,17 @@ class CarouselButton(discord.ui.Button):
     user_badges = db_get_user_badges(self.user_discord_id)
     completed_badges = self.view.completed_badges
     valid_badges = [b for b in user_badges if b['badge_name'] not in completed_badges]
+
+    if len(valid_badges) == 0:
+      await interaction.respond(
+        embed=discord.Embed(
+          title="You're done!",
+          description="You've completed tagging every badge in your inventory! Nice."
+        ),
+        ephemeral=True
+      )
+      return
+
     next_badge = random.choice(valid_badges)
 
     completed_badges.append(next_badge['badge_name'])


### PR DESCRIPTION
Once they've run out of badges, provide an error message and return without a new view.