### PR TITLE
Retain Existing Tags For Tags Carousel

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v1.29.6
-appVersion: v1.29.6
+version: v1.29.7
+appVersion: v1.29.7

--- a/cogs/badge_tags.py
+++ b/cogs/badge_tags.py
@@ -151,7 +151,8 @@ class CarouselButton(discord.ui.Button):
     next_badge = random.choice(valid_badges)
 
     completed_badges.append(next_badge['badge_name'])
-    next_tag_ids = db_get_associated_badge_tags(self.user_discord.id, next_badge['badge_name'])
+    next_tags = db_get_associated_badge_tags(self.user_discord_id, next_badge['badge_name'])
+    next_tag_ids = [str(t['id']) for t in next_tags]
 
     new_view = TagCarouselView(self.user_discord_id, completed_badges, next_badge, next_tag_ids)
     embed = discord.Embed(
@@ -607,9 +608,10 @@ class BadgeTags(commands.Cog):
 
     user_badges = db_get_user_badges(ctx.author.id)
     initial_badge = random.choice(user_badges)
-    initial_tag_ids = db_get_associated_badge_tags(self.user_discord.id, initial_badge['badge_name'])
+    next_tags = db_get_associated_badge_tags(ctx.author.id, initial_badge['badge_name'])
+    next_tag_ids = [str(t['id']) for t in next_tags]
 
-    view = TagCarouselView(ctx.author.id, [initial_badge['badge_name']], initial_badge, initial_tag_ids)
+    view = TagCarouselView(ctx.author.id, [initial_badge['badge_name']], initial_badge, next_tag_ids)
     embed = discord.Embed(
       title=initial_badge['badge_name'],
       color=discord.Color.dark_purple()

--- a/cogs/badge_tags.py
+++ b/cogs/badge_tags.py
@@ -151,8 +151,9 @@ class CarouselButton(discord.ui.Button):
     next_badge = random.choice(valid_badges)
 
     completed_badges.append(next_badge['badge_name'])
+    next_tag_ids = db_get_associated_badge_tags(self.user_discord.id, next_badge['badge_name'])
 
-    new_view = TagCarouselView(self.user_discord_id, completed_badges, next_badge)
+    new_view = TagCarouselView(self.user_discord_id, completed_badges, next_badge, next_tag_ids)
     embed = discord.Embed(
       title=next_badge['badge_name'],
       color=discord.Color.dark_purple()
@@ -174,11 +175,11 @@ class TagBadgeView(discord.ui.View):
 
 
 class TagCarouselView(discord.ui.View):
-  def __init__(self, user_discord_id, completed_badges, next_badge):
+  def __init__(self, user_discord_id, completed_badges, next_badge, tag_ids):
     super().__init__()
     self.user_discord_id = user_discord_id
     self.completed_badges = completed_badges
-    self.tag_ids = []
+    self.tag_ids = tag_ids
     self.add_item(TagSelector(user_discord_id, next_badge['badge_name']))
     self.add_item(CarouselButton(user_discord_id, next_badge['badge_name']))
 
@@ -606,8 +607,9 @@ class BadgeTags(commands.Cog):
 
     user_badges = db_get_user_badges(ctx.author.id)
     initial_badge = random.choice(user_badges)
+    initial_tag_ids = db_get_associated_badge_tags(self.user_discord.id, initial_badge['badge_name'])
 
-    view = TagCarouselView(ctx.author.id, [initial_badge['badge_name']], initial_badge)
+    view = TagCarouselView(ctx.author.id, [initial_badge['badge_name']], initial_badge, initial_tag_ids)
     embed = discord.Embed(
       title=initial_badge['badge_name'],
       color=discord.Color.dark_purple()


### PR DESCRIPTION
Borked some logic where we weren't maintaining the existing tags when we fired the button for `/tags carousel`

Fixt now (I hope 🤞)