### PR TITLE
Add pagination for `/drop list` command

### DIFF
--- a/commands/drop.py
+++ b/commands/drop.py
@@ -39,15 +39,15 @@ async def drop_list(ctx: discord.ApplicationContext):
 
   drop_names = drop_data.keys()
   drop_pages = ['']
-  drop_name_idx = 0
 
-  while drop_name_idx < len(drop_names):
-    # 5000 char to give a reasonable buffer for the 6000 char limit for embeds
-    # there may be a more precise way to do this using `embed.len()` but modifying the `embed` after it's constructed seems like a PITA --thousand
-    if len(drop_pages[-1]) > 5000:
+  for drop_name in drop_names:
+    # 4000 char to give a reasonable buffer for the 4096 char limit for embed description field
+    # N.B., the longest drop name at time of authoring is "He Just Kept Talking In One Long Incredibly Unbroken Sentence" at 61 chars
+    # there may be a more precise and long term reliable way to do this using `embed.len()` but modifying the `embed` after it's constructed seems like a PITA --thousand
+    if len(drop_pages[-1]) > 4000:
       drop_pages.append('')
     sep = '\n' if len(drop_pages[-1]) > 0 else ''
-    drop_pages[-1] += f"{drop_names[drop_name_idx]}{sep}"
+    drop_pages[-1] += f"{sep}{drop_name}"
 
   for page_idx in range(len(drop_pages)):
     embed = discord.Embed(

--- a/commands/drop.py
+++ b/commands/drop.py
@@ -49,12 +49,18 @@ async def drop_list(ctx: discord.ApplicationContext):
     sep = '\n' if len(drop_pages[-1]) > 0 else ''
     drop_pages[-1] += f"{sep}{drop_name}"
 
+  # Aggy's avatar for the footer
+  avatar_asset = bot.user.avatar
+  avatar_url = avatar_asset.with_size(128).url
+
   for page_idx in range(len(drop_pages)):
     embed = discord.Embed(
-      title=f"List of Drops (page {page_idx+1}/{len(drop_pages)})",
+      title=f"List of Drops",
       description=drop_pages[page_idx],
-      color=discord.Color.blue()
+      color=discord.Color.blue(),
     )
+    embed.set_footer(
+      text=f"Page {page_idx+1} of {len(drop_pages)}", icon_url=avatar_url)
     user = get_user(ctx.author.id)
     if user['receive_notifications']:
       try:

--- a/commands/drop.py
+++ b/commands/drop.py
@@ -10,7 +10,8 @@ f = open(command_config["data"])
 drop_data = json.load(f)
 f.close()
 
-async def drop_autocomplete(ctx:discord.AutocompleteContext):
+
+async def drop_autocomplete(ctx: discord.AutocompleteContext):
   results = []
   for drop_key in drop_data.keys():
     drop_info = drop_data[drop_key]
@@ -23,31 +24,51 @@ async def drop_autocomplete(ctx:discord.AutocompleteContext):
 # Create drop Slash Command Group
 drop = bot.create_group("drop", "Drop Commands!")
 
+
 @drop.command(
   name="list",
   description="Retrieve the List of Drops"
 )
-async def drop_list(ctx:discord.ApplicationContext):
+async def drop_list(ctx: discord.ApplicationContext):
   """
   Entrypoint for `/drops list`` command
   List the available drops by key and send to user as ephemeral
   """
-  logger.info(f"{Fore.RED}Firing `/drop list` command, requested by {ctx.author.name}!{Fore.RESET}")
-  drops_list = "\n".join(drop_data)
-  embed = discord.Embed(
-    title="List of Drops",
-    description=drops_list,
-    color=discord.Color.blue()
-  )
-  user = get_user(ctx.author.id)
-  if user['receive_notifications']:
-    try:
-      await ctx.author.send(embed=embed)
-      await ctx.respond(f"{get_emoji('tendi_smile_happy')} Sent you a DM with the full List of Drops!", ephemeral=True)
-    except BaseException as e:
+  logger.info(
+    f"{Fore.RED}Firing `/drop list` command, requested by {ctx.author.name}!{Fore.RESET}")
+
+  drop_names = drop_data.keys()
+  drop_pages = ['']
+  drop_name_idx = 0
+
+  while drop_name_idx < len(drop_names):
+    # 5000 char to give a reasonable buffer for the 6000 char limit for embeds
+    # there may be a more precise way to do this using `embed.len()` but modifying the `embed` after it's constructed seems like a PITA --thousand
+    if len(drop_pages[-1]) > 5000:
+      drop_pages.append('')
+    sep = '\n' if len(drop_pages[-1]) > 0 else ''
+    drop_pages[-1] += f"{drop_names[drop_name_idx]}{sep}"
+
+  for page_idx in range(len(drop_pages)):
+    embed = discord.Embed(
+      title=f"List of Drops (page {page_idx+1}/{len(drop_pages)})",
+      description=drop_pages[page_idx],
+      color=discord.Color.blue()
+    )
+    user = get_user(ctx.author.id)
+    if user['receive_notifications']:
+      try:
+        await ctx.author.send(embed=embed)
+        # Don't do this notice more than once, that would be silly
+        if page_idx == 0:
+          await ctx.respond(f"{get_emoji('tendi_smile_happy')} Sent you a DM with the full List of Drops!", ephemeral=True)
+        else:
+          pass  # noop
+      except BaseException as e:
+        await ctx.respond(embed=embed, ephemeral=True)
+    else:
       await ctx.respond(embed=embed, ephemeral=True)
-  else:
-    await ctx.respond(embed=embed, ephemeral=True)
+
 
 @drop.command(
   name="post",
@@ -75,14 +96,15 @@ async def drop_list(ctx:discord.ApplicationContext):
   autocomplete=drop_autocomplete
 )
 @commands.check(access_check)
-async def drop_post(ctx:discord.ApplicationContext, public:str, query:str):
+async def drop_post(ctx: discord.ApplicationContext, public: str, query: str):
   """
   Entrypoint for `/drops post` command
   Parses a query, determines if it's allowed in the channel,
   and if allowed retrieve from metadata to do matching and
   then send the .mp4 file
   """
-  logger.info(f"{Fore.RED}Firing `/drop post` command, requested by {ctx.author.name}!{Fore.RESET}")
+  logger.info(
+    f"{Fore.RED}Firing `/drop post` command, requested by {ctx.author.name}!{Fore.RESET}")
   # Private drops are not on the timer
   public = bool(public == "yes")
   allowed = True


### PR DESCRIPTION
Splits the list of drops into an appropriate number of embeds such that each payload is <4096 characters and sends each one. Given the length of the list, this seemed like an easier way to view all the options than having a paginated embed.