### PR TITLE
Tongo Tweaks and Misc

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v2.3.1
-appVersion: v2.3.1
+version: v2.3.2
+appVersion: v2.3.2

--- a/cogs/tongo.py
+++ b/cogs/tongo.py
@@ -80,7 +80,6 @@ class Tongo(commands.Cog):
   )
   @commands.check(access_check)
   async def venture(self, ctx:discord.ApplicationContext, first_badge:str, second_badge:str, third_badge:str):
-    await ctx.defer(ephemeral=True)
     user_discord_id = ctx.interaction.user.id
     user_member = await self.bot.current_guild.fetch_member(user_discord_id)
     active_tongo = db_get_active_tongo()
@@ -121,7 +120,7 @@ class Tongo(commands.Cog):
       description=f"A new Tongo game has begun!!!\n\n**{user_member.display_name}** has kicked things off and is The Chair!\n\n"
                   "Only *they* have the ability to end the game via `/tongo confront`!\n\n"
                   f"If **{user_member.display_name}** does not Confront within 8 hours, this game will automatically end and "
-                  "the badge distribution from The Continium will automatically occur!",
+                  "the badge distribution from The Continuum will automatically occur!",
       color=discord.Color.dark_purple()
     )
     confirmation_embed.add_field(
@@ -349,7 +348,7 @@ class Tongo(commands.Cog):
     if self.auto_confront.next_iteration:
       current_time = datetime.now(timezone.utc)
       remaining_time = current_time - self.auto_confront.next_iteration
-      description += f"This Tongo game has {humanize.naturaltime(remaining_time, minimum_unit='minutes')} left before the game is automatically ended!"
+      description += f"This Tongo game has {humanize.naturaltime(remaining_time)} left before the game is automatically ended!"
 
     confirmation_embed = discord.Embed(
       title="TONGO! Call For Index!",
@@ -454,6 +453,10 @@ class Tongo(commands.Cog):
         inline=False
       )
     results_embed.set_image(url="https://i.imgur.com/gdpvba5.gif")
+    results_embed.set_footer(
+      text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}",
+      icon_url="https://i.imgur.com/GTN4gQG.jpg"
+    )
     channel_message = await ctx.channel.send(embed=results_embed)
 
     for result in results.items():
@@ -503,6 +506,9 @@ class Tongo(commands.Cog):
             name="Wishlisted Badges Received",
             value="\n".join([f"* {b['badge_name']}" for b in wishlist_badges_received])
           )
+        player_message_embed.set_footer(
+          text="Note you can use /settings to enable or disable these messages."
+        )
         try:
           await player_member.send(embed=player_message_embed)
         except discord.Forbidden as e:
@@ -523,6 +529,9 @@ class Tongo(commands.Cog):
           color=discord.Color.dark_purple()
         )
         player_message_embed.set_image(url="https://i.imgur.com/qZNBAvE.gif")
+        player_message_embed.set_footer(
+          text="Note you can use /settings to enable or disable these messages."
+        )
         try:
           await player_member.send(embed=player_message_embed)
         except discord.Forbidden as e:
@@ -581,6 +590,10 @@ class Tongo(commands.Cog):
         inline=False
       )
     results_embed.set_image(url="https://i.imgur.com/gdpvba5.gif")
+    results_embed.set_footer(
+      text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}",
+      icon_url="https://i.imgur.com/GTN4gQG.jpg"
+    )
     trade_channel = await self.bot.fetch_channel(get_channel_id("bahrats-bazaar"))
     channel_message = await trade_channel.send(embed=results_embed)
 
@@ -631,6 +644,9 @@ class Tongo(commands.Cog):
             name="Wishlisted Badges Received",
             value="\n".join([f"* {b['badge_name']}" for b in wishlist_badges_received])
           )
+        player_message_embed.set_footer(
+          text="Note you can use /settings to enable or disable these messages."
+        )
         try:
           await player_member.send(embed=player_message_embed)
         except discord.Forbidden as e:
@@ -651,6 +667,9 @@ class Tongo(commands.Cog):
           color=discord.Color.dark_purple()
         )
         player_message_embed.set_image(url="https://i.imgur.com/qZNBAvE.gif")
+        player_message_embed.set_footer(
+          text="Note you can use /settings to enable or disable these messages."
+        )
         try:
           await player_member.send(embed=player_message_embed)
         except discord.Forbidden as e:

--- a/cogs/tongo.py
+++ b/cogs/tongo.py
@@ -613,13 +613,13 @@ class Tongo(commands.Cog):
           )
           db_purge_users_wishlist(player_user_discord_id)
         player_embed.set_image(url=f"attachment://{won_image_id}.png")
-        confirmation_message = await trade_channel.send(embed=player_embed, file=won_image)
+        await trade_channel.send(embed=player_embed, file=won_image)
 
         # Now send message to the player
         player_message_embed = discord.Embed(
           title=f"TONGO! Game Automatically Ending!",
           description="Time ran out for your Tongo game and it has automatically ended! Your winnings are included below, "
-                      f"and you can view the full results at: {confirmation_message.jump_url}",
+                      f"and you can view the full results at: {channel_message.jump_url}",
           color=discord.Color.dark_purple()
         )
         player_message_embed.add_field(

--- a/cogs/tongo.py
+++ b/cogs/tongo.py
@@ -477,7 +477,7 @@ class Tongo(commands.Cog):
           description="\n".join([f"* {b['badge_name']}" for b in player_badges_received]),
           color=discord.Color.dark_purple()
         )
-        wishlist_badges_received = [b for b in player_wishlist if b['badge_filename'] in player_badges_received]
+        wishlist_badges_received = [b for b in player_wishlist if b['badge_filename'] in [b['badge_filename'] for b in player_badges_received]]
         if wishlist_badges_received:
           player_embed.add_field(
             name="Wishlisted Badges Received",
@@ -605,7 +605,7 @@ class Tongo(commands.Cog):
           description="\n".join([f"* {b['badge_name']}" for b in player_badges_received]),
           color=discord.Color.dark_purple()
         )
-        wishlist_badges_received = [b for b in player_wishlist if b['badge_filename'] in player_badges_received]
+        wishlist_badges_received = [b for b in player_wishlist if b['badge_filename'] in [b['badge_filename'] for b in player_badges_received]]
         if wishlist_badges_received:
           player_embed.add_field(
             name="Wishlisted Badges Received",

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -363,7 +363,10 @@ class Trade(commands.Cog):
     )
     success_image = discord.File(fp=f"./images/trades/assets/{image_filename}", filename=image_filename)
     success_embed.set_image(url=f"attachment://{image_filename}")
-    success_embed.set_footer(text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}")
+    success_embed.set_footer(
+      text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}",
+      icon_url="https://i.imgur.com/GTN4gQG.jpg"
+    )
 
     channel = interaction.channel
     message = await channel.send(embed=success_embed, file=success_image)
@@ -800,7 +803,10 @@ class Trade(commands.Cog):
       name=f"Badges requested from {requestee.display_name}",
       value=request
     )
-    initiated_embed.set_footer(text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}")
+    initiated_embed.set_footer(
+      text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}",
+      icon_url="https://i.imgur.com/GTN4gQG.jpg"
+    )
 
     initiated_image = discord.File(fp="./images/trades/assets/trade_pending.png", filename="trade_pending.png")
     initiated_embed.set_image(url=f"attachment://trade_pending.png")
@@ -933,7 +939,10 @@ class Trade(commands.Cog):
       name=f"Badges requested from {requestee.display_name}",
       value="\n".join([f"* {b}" for b in random_requests])
     )
-    dabo_embed.set_footer(text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}")
+    dabo_embed.set_footer(
+      text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}",
+      icon_url="https://i.imgur.com/GTN4gQG.jpg"
+    )
 
     dabo_image = discord.File(fp="./images/trades/assets/dabo.png", filename="dabo.png")
     dabo_embed.set_image(url=f"attachment://dabo.png")
@@ -1374,7 +1383,10 @@ class Trade(commands.Cog):
       name=f"Requested from {requestee.display_name}",
       value=requested_badge_names
     )
-    home_embed.set_footer(text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}")
+    home_embed.set_footer(
+      text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}",
+      icon_url="https://i.imgur.com/GTN4gQG.jpg"
+    )
     home_image = discord.File(fp=f"./images/trades/assets/{image_filename}", filename=image_filename)
     home_embed.set_image(url=f"attachment://{image_filename}")
 

--- a/data/drops.json
+++ b/data/drops.json
@@ -234,6 +234,11 @@
     "description": "Adam Gonna Need A Lockdown Song",
     "url": "https://i.imgur.com/5jcMZg8.mp4"
   },
+  "Gotta Have Weps, He's The Key": {
+    "file": "data/drops/gottahaveweps.mp4",
+    "description": "Crimson Tide Gotta Have Weps He's The Key",
+    "url": "https://i.imgur.com/SkEHUpj.mp4"
+  },
   "Greatest Gen Con/Khan (AIRHORNS!!!)": {
     "file": "data/drops/airhorns.mp4",
     "description": "Greatest Gen Con Khan Airhorns",

--- a/data/react_roles/notifications.json
+++ b/data/react_roles/notifications.json
@@ -33,6 +33,11 @@
       "emoji": "📚",
       "role": "Book Lover",
       "description": "Get notified when **Book-related** events are happening (Book Club!)"
+    },
+    {
+      "emoji": "🦡",
+      "role": "Badger",
+      "description": "Get notified when **Badge Trading-related** features or feedback are released/requested"
     }
   ]
 }

--- a/handlers/save_message.py
+++ b/handlers/save_message.py
@@ -2,6 +2,8 @@ from common import *
 from utils import string_utils
 from wordcloud import STOPWORDS
 
+user_string_pattern = re.compile("^a\d+$")
+
 # save_message_to_db() - saves a users message to the database after doing some cleanup on the message 
 # strips emoji and converts message to basic ascii, shuffles words in message, sorts words in message
 # used for wordcloud only at the moment!
@@ -29,6 +31,10 @@ async def save_message_to_db(message:discord.Message):
     message_content = " ".join(message_modified)
 
     if message_content == "":
+      return None
+
+    if user_string_pattern.match(message_content):
+      # Don't log mentions
       return None
 
     with AgimusDB() as query:


### PR DESCRIPTION
* Fix up some issues with Aggy not "acknowledging" the tongo commands
* Wishlist handouts now supported
* Added "Badge Trader" notification role
* Wordcloud should no longer log user mention strings
* Added Quark Icon to Trade/Dabo/Tongo channel messages
* Added "Gotta Have Weps, He's The Key" drop