### PR TITLE
Fix Tongo Risk Followup

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v2.3.3
-appVersion: v2.3.3
+version: v2.3.4
+appVersion: v2.3.4

--- a/cogs/tongo.py
+++ b/cogs/tongo.py
@@ -23,8 +23,9 @@ async def risk_autocomplete(ctx:discord.AutocompleteContext):
   third_badge = ctx.options["third_badge"]
 
   user_badges = db_get_user_unlocked_badges(ctx.interaction.user.id)
+  tongo_pot = db_get_tongo_pot_badges()
 
-  filtered_badges = [first_badge, second_badge, third_badge] + [b['badge_name'] for b in SPECIAL_BADGES]
+  filtered_badges = [first_badge, second_badge, third_badge] + [b['badge_name'] for b in tongo_pot] + [b['badge_name'] for b in SPECIAL_BADGES]
 
   filtered_badge_names = [badge['badge_name'] for badge in user_badges if badge['badge_name'] not in filtered_badges]
 
@@ -762,7 +763,7 @@ class Tongo(commands.Cog):
   # \____/\__/_/_/_/\__/_/\__/___/
   async def _validate_selected_user_badges(self, ctx:discord.ApplicationContext, selected_user_badges):
     if len(selected_user_badges) != 3:
-      await ctx.followup.send(embed=discord.Embed(
+      await ctx.respond(embed=discord.Embed(
         title="Invalid Selection",
         description=f"You must own all of the badges you've selected to risk and they must be unlocked!",
         color=discord.Color.red()
@@ -770,7 +771,7 @@ class Tongo(commands.Cog):
       return False
 
     if len(selected_user_badges) > len(set(selected_user_badges)):
-      await ctx.followup.send(embed=discord.Embed(
+      await ctx.respond(embed=discord.Embed(
         title="Invalid Selection",
         description=f"All badges selected must be unique!",
         color=discord.Color.red()
@@ -779,7 +780,7 @@ class Tongo(commands.Cog):
 
     restricted_badges = [b for b in selected_user_badges if b in [b['badge_name'] for b in SPECIAL_BADGES]]
     if restricted_badges:
-      await ctx.followup.send(embed=discord.Embed(
+      await ctx.respond(embed=discord.Embed(
         title="Invalid Selection",
         description=f"You cannot risk with the following: {','.join(restricted_badges)}!",
         color=discord.Color.red()
@@ -789,7 +790,7 @@ class Tongo(commands.Cog):
     tongo_pot_badges = db_get_tongo_pot_badges()
     existing_pot_badges = [b for b in selected_user_badges if b in [b['badge_name'] for b in tongo_pot_badges]]
     if existing_pot_badges:
-      await ctx.followup.send(embed=discord.Embed(
+      await ctx.respond(embed=discord.Embed(
         title="Invalid Selection",
         description=f"The following badges are already in The Great Material Continuum: {','.join(existing_pot_badges)}!",
         color=discord.Color.red()

--- a/data/drops.json
+++ b/data/drops.json
@@ -109,6 +109,11 @@
     "description": "I'm receiving a Code 47. Verify. It is Code 47 sir, starfleet emergency frequency. Captain's Eyes Only.",
     "url": "https://i.imgur.com/0wGwaF2.mp4"
   },
+  "Commander Riker's Quarters": {
+    "file": "data/drops/commanderrikersquarters.mp4",
+    "description": "The Commander Rikers Quarters Drop Commander Riker's Quarters",
+    "url": "https://i.imgur.com/4cUxThX.mp4"
+  },
   "Crystals!": {
     "file": "data/drops/crystals.mp4",
     "description": "Crystals!",
@@ -783,6 +788,11 @@
     "file": "data/drops/thestarborndrop.mp4",
     "description": "The Starborn Drop. User drop.",
     "url": "https://i.imgur.com/IarPe1v.mp4"
+  },
+  "The Tarquynn Drop": {
+    "file": "data/drops/thetarquynndrop.mp4",
+    "description": "The Tarquynn Drop. User drop.",
+    "url": "https://i.imgur.com/lxzVoJ0.mp4"
   },
   "The Taq Drop": {
     "file": "data/drops/thetaqdrop.mp4",


### PR DESCRIPTION
Used the wrong method here, fixing.

Also filter out the 'tongo_pot' from the autocomplete. 🤦 

And add 2 new drops:
* Commander Riker's Quarters
* The Tarqyunn Drop