### PR TITLE
Fix bot love/sass so that it will trigger when:

### DIFF
--- a/bot_condemnations.txt
+++ b/bot_condemnations.txt
@@ -1,4 +1,5 @@
 bad
+evil
 lousy
 mean
 rude

--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v2.3.4
-appVersion: v2.3.4
+version: v2.3.5
+appVersion: v2.3.5

--- a/handlers/bot_autoresponse.py
+++ b/handlers/bot_autoresponse.py
@@ -1,4 +1,10 @@
-from common import *
+import random
+import re
+
+import discord
+from colorama import Fore
+
+from common import get_emoji, logger, BOT_NAME, config
 
 # Load up our list of complimentary and condemnation adjectives
 with open('bot_affirmations.txt') as f:
@@ -19,13 +25,14 @@ async def handle_bot_affirmations(message:discord.Message):
     await message.add_reaction(get_emoji("agimus"))
 
   for condemnation in bot_condemnations:
-    if (re.match(fr".*{condemnation} bot[^\w\s]+", message_content)) or (re.match(fr".*{condemnation} bot$", message_content)):
-      if not (re.match(fr".*not a?\s?{condemnation} bot", message_content)):
+    if re.search(fr"{condemnation} bot\b", message_content):
+      if not re.search(fr"not a?\s?{condemnation} bot", message_content):
         await respond_to_sass(message)
+        return
 
   for affirmation in bot_affirmations:
-    if (re.match(fr".*{affirmation} bot[^\w\s]+", message_content)) or (re.match(fr".*{affirmation} bot$", message_content)):
-      if re.match(fr".*not a?\s?{affirmation} bot", message_content):
+    if re.search(fr"{affirmation} bot\b", message_content):
+      if re.search(fr"not a?\s?{affirmation} bot", message_content):
         await respond_to_sass(message)
         return
       else:


### PR DESCRIPTION
* The word “bot” is followed by a space
* It’s part of a multi-line message
* Someone calls Aggy an “evil bot”
* Not respond to both praise and hate 
As a side effect, it should be faster