### PR TITLE
Make Starboard Pattern Globals Local Instead

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v2.5.0
-appVersion: v2.5.0
+version: v2.5.1
+appVersion: v2.5.1

--- a/handlers/starboard.py
+++ b/handlers/starboard.py
@@ -14,16 +14,11 @@ high_react_threshold = 5
 argus_threshold = 10 # not being used yet
 user_threshold = 3 # how many users required
 
-board_patterns = blocked_channels = boards = high_react_channel_ids = None
-
-
 async def handle_starboard_reactions(payload:discord.RawReactionActionEvent) -> None:
-  global board_patterns, blocked_channels, boards, high_react_channel_ids
-  if board_patterns is None:
-    board_patterns = generate_board_compiled_patterns(config["handlers"]["starboard"]["boards"])
-    blocked_channels = get_channel_ids_list(config["handlers"]["starboard"]["blocked_channels"])
-    boards = get_channel_ids_list(board_patterns.keys())
-    high_react_channel_ids = get_channel_ids_list(config["handlers"]["starboard"]["high_react_channels"])
+  board_patterns = generate_board_compiled_patterns(config["handlers"]["starboard"]["boards"])
+  blocked_channels = get_channel_ids_list(config["handlers"]["starboard"]["blocked_channels"])
+  boards = get_channel_ids_list(board_patterns.keys())
+  high_react_channel_ids = get_channel_ids_list(config["handlers"]["starboard"]["high_react_channels"])
 
   if payload.message_id in ALL_STARBOARD_POSTS:
     return


### PR DESCRIPTION
We get weird behavior occasionally where posts that shouldn't be showing up in the starboards leak through from sensitive channels and I think it just has to do with how we're casting these as globals.

It's nice to only put them together once but the operations themselves are simple (tiny) array traversals and so small that I don't think it's really a big detriment if they're done on the fly going forward.