### PR TITLE
Store Last `/tags carousel` Badge Position

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v2.6.4
-appVersion: v2.6.4
+version: v2.7.0
+appVersion: v2.7.0

--- a/data/seed-db.sql
+++ b/data/seed-db.sql
@@ -304,14 +304,14 @@ CREATE TABLE IF NOT EXISTS xp_cap_progress (
   `user_discord_id` varchar(64) NOT NULL,
   `progress` int(4) NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE (`user_discord_id`)  
+  UNIQUE (`user_discord_id`)
 );
 CREATE TABLE IF NOT EXISTS down_to_dabo (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_discord_id` varchar(64) NOT NULL,
   `weight` int(4) NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE (`user_discord_id`)  
+  UNIQUE (`user_discord_id`)
 );
 CREATE TABLE IF NOT EXISTS tongo (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -337,4 +337,15 @@ CREATE TABLE IF NOT EXISTS tongo_pot (
   PRIMARY KEY (`id`),
   KEY `badge_filename` (`badge_filename`),
   CONSTRAINT `badge_tongo_pot_fk_badge_filename` FOREIGN KEY (`badge_filename`) REFERENCES `badge_info` (`badge_filename`)
+);
+CREATE TABLE IF NOT EXISTS tags_carousel_position (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_discord_id` varchar(64) NOT NULL,
+  `badge_filename` VARCHAR(128) DEFAULT '' NOT NULL,
+  `last_modified` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP(),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY (`user_discord_id`),
+  UNIQUE KEY `uID_bID` (`user_discord_id`, `badge_filename`),
+  KEY `badge_filename` (`badge_filename`),
+  CONSTRAINT `badge_tags_carousel_position_fk_badge_filename` FOREIGN KEY (`badge_filename`) REFERENCES `badge_info` (`badge_filename`)
 );

--- a/queries/badge_tags.py
+++ b/queries/badge_tags.py
@@ -123,8 +123,12 @@ def db_get_user_tagged_badges(user_discord_id, tag):
     badges = query.fetchall()
   return badges
 
-def db_get_last_tagged_badge_filename(user_discord_id):
+def db_get_last_carousel_tagged_badge_filename(user_discord_id):
   with AgimusDB(dictionary=True) as query:
+    """
+      returns the badge_filename value from the tags_carousel_position
+      associated with the user_discord_id, otherwise if no row return One
+    """
     sql = '''
       SELECT badge_filename FROM tags_carousel_position WHERE user_discord_id = %s LIMIT 1;
     '''
@@ -136,7 +140,7 @@ def db_get_last_tagged_badge_filename(user_discord_id):
   else:
     return None
 
-def db_upsert_last_tagged_badge_filename(user_discord_id, badge_filename):
+def db_upsert_last_carousel_tagged_badge_filename(user_discord_id, badge_filename):
   """
   either creates or modifies the user's tags_carousel_position row
   with the given badge_filename to indicate the last badge they've tagged
@@ -153,7 +157,7 @@ def db_upsert_last_tagged_badge_filename(user_discord_id, badge_filename):
     vals = (user_discord_id, badge_filename, badge_filename)
     query.execute(sql, vals)
 
-def db_clear_last_tagged_badge_filename(user_discord_id):
+def db_clear_last_carousel_tagged_badge_filename(user_discord_id):
   """
   deletes the user's record from the tags_carousel_position table
   so that the next time they load the interface they'll start at the front again

--- a/queries/badge_tags.py
+++ b/queries/badge_tags.py
@@ -46,7 +46,7 @@ def db_rename_user_tag(user_discord_id, tag, new_name) -> None:
     vals = (new_name, user_discord_id, tag)
     query.execute(sql, vals)
 
-def db_get_associated_badge_tags(user_discord_id, badge_name) -> list:
+def db_get_associated_badge_tags(user_discord_id, badge_filename) -> list:
   """
   returns a list of the current tags the user has associated with a given badge
   """
@@ -56,21 +56,21 @@ def db_get_associated_badge_tags(user_discord_id, badge_name) -> list:
         JOIN badge_tags_associations AS t_a ON b_t.id = t_a.badge_tags_id
         JOIN badges AS b ON t_a.badges_id = b.id
         JOIN badge_info AS b_i ON b_i.badge_filename = b.badge_filename
-          WHERE b_i.badge_name = %s AND b_t.user_discord_id = %s
+          WHERE b_i.badge_filename = %s AND b_t.user_discord_id = %s
     '''
-    vals = (badge_name, user_discord_id)
+    vals = (badge_filename, user_discord_id)
     query.execute(sql, vals)
     results = query.fetchall()
   return results
 
 
-def db_create_badge_tags_associations(user_discord_id, badge_name, tag_ids):
+def db_create_badge_tags_associations(user_discord_id, badge_filename, tag_ids):
   """
   associates a list of tags with a user's specific badge
   """
   tags_values_list = []
   for id in tag_ids:
-    tuple = (id, badge_name, user_discord_id)
+    tuple = (id, badge_filename, user_discord_id)
     tags_values_list.append(tuple)
 
   with AgimusDB(dictionary=True) as query:
@@ -79,7 +79,7 @@ def db_create_badge_tags_associations(user_discord_id, badge_name, tag_ids):
         SELECT b.id, %s
           FROM badges AS b
           JOIN badge_info AS b_i ON b_i.badge_filename = b.badge_filename
-            WHERE b_i.badge_name = %s AND b.user_discord_id = %s
+            WHERE b_i.badge_filename = %s AND b.user_discord_id = %s
     '''
     query.executemany(sql, tags_values_list)
 
@@ -122,3 +122,45 @@ def db_get_user_tagged_badges(user_discord_id, tag):
     query.execute(sql, vals)
     badges = query.fetchall()
   return badges
+
+def db_get_last_tagged_badge_filename(user_discord_id):
+  with AgimusDB(dictionary=True) as query:
+    sql = '''
+      SELECT badge_filename FROM tags_carousel_position WHERE user_discord_id = %s LIMIT 1;
+    '''
+    vals = (user_discord_id,)
+    query.execute(sql, vals)
+    results = query.fetchone()
+  if results:
+    return results['badge_filename']
+  else:
+    return None
+
+def db_upsert_last_tagged_badge_filename(user_discord_id, badge_filename):
+  """
+  either creates or modifies the user's tags_carousel_position row
+  with the given badge_filename to indicate the last badge they've tagged
+  """
+  with AgimusDB() as query:
+    sql = '''
+      INSERT INTO tags_carousel_position
+        (user_discord_id, badge_filename)
+      VALUES
+        (%s, %s)
+      ON DUPLICATE KEY UPDATE
+        badge_filename = %s
+    '''
+    vals = (user_discord_id, badge_filename, badge_filename)
+    query.execute(sql, vals)
+
+def db_clear_last_tagged_badge_filename(user_discord_id):
+  """
+  deletes the user's record from the tags_carousel_position table
+  so that the next time they load the interface they'll start at the front again
+  """
+  with AgimusDB() as query:
+    sql = '''
+      DELETE FROM tags_carousel_position WHERE user_discord_id = %s
+    '''
+    vals = (user_discord_id,)
+    query.execute(sql, vals)


### PR DESCRIPTION
Little update to `/tags carousel`. Through a new `tags_carousel_position` table, we now track when a user moves forward through the carousel. If they halt their current progress and start a new session, they can either start from the beginning again or resume where they left off through a required `start` option.