### PR TITLE
`/badges status` and `/wishlist find_traders`

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v2.7.2
-appVersion: v2.7.2
+version: v2.7.3
+appVersion: v2.7.3

--- a/cogs/wishlist.py
+++ b/cogs/wishlist.py
@@ -706,10 +706,6 @@ class Wishlist(commands.Cog):
     badge_trader_role = discord.utils.get(bot.current_guild.roles, name=config['roles']['badge_traders'])
     badge_trader_ids = [m.id for m in badge_trader_role.members]
 
-    # Housekeeping
-    # Clear any badges from the users wishlist that the user may already possess currently
-    db_purge_users_wishlist(author_discord_id)
-
     # Get all the users and the badgenames that want badges that the user has
     inventory_matches = db_get_wishlist_inventory_matches(author_discord_id)
     inventory_aggregate = {}
@@ -762,7 +758,7 @@ class Wishlist(commands.Cog):
       await ctx.followup.send(
         embed=discord.Embed(
           title="No Traders Found",
-          description="Unable to find any Traders who are interested in items from your unlocked inventory.\n\nPlease try again later!",
+          description="Unable to find any Traders who are interested in items from your Unlocked Inventory.\n\nPlease try again later!",
           color=discord.Color.blurple()
         ), ephemeral=True
       )

--- a/cogs/wishlist.py
+++ b/cogs/wishlist.py
@@ -676,6 +676,97 @@ class Wishlist(commands.Cog):
           if has_badges_names != dismissal_has and wants_badges_names != dismissal_wants:
             db_delete_wishlist_dismissal(author_discord_id, user_id)
 
+
+  # ___________.__            .___ ___________                  .___
+  # \_   _____/|__| ____    __| _/ \__    ___/___________     __| _/___________  ______
+  #  |    __)  |  |/    \  / __ |    |    |  \_  __ \__  \   / __ |/ __ \_  __ \/  ___/
+  #  |     \   |  |   |  \/ /_/ |    |    |   |  | \// __ \_/ /_/ \  ___/|  | \/\___ \
+  #  \___  /   |__|___|  /\____ |    |____|   |__|  (____  /\____ |\___  >__|  /____  >
+  #      \/            \/      \/                        \/      \/    \/           \/
+  @wishlist_group.command(
+    name="find_traders",
+    description="Find Badge Traders who want Badges from your Unlocked Inventory."
+  )
+  async def find_traders(self, ctx:discord.ApplicationContext):
+    await ctx.defer(ephemeral=True)
+    author_discord_id = ctx.author.id
+
+    logger.info(f"{ctx.author.display_name} is attempting to {Style.BRIGHT}find traders{Style.RESET_ALL} for items in their {Style.BRIGHT}unlocked inventory{Style.RESET_ALL}")
+
+    initial_followup = await ctx.followup.send(
+      embed=discord.Embed(
+        title="Finding Traders...",
+        description="Uno tomatoes por favor...",
+        color=discord.Color.blurple()
+      ),
+      ephemeral=True
+    )
+
+    # Get list of badge trader userids, we'll filter out any matches that don't have the role
+    badge_trader_role = discord.utils.get(bot.current_guild.roles, name=config['roles']['badge_traders'])
+    badge_trader_ids = [m['id'] for m in badge_trader_role.members]
+
+    # Housekeeping
+    # Clear any badges from the users wishlist that the user may already possess currently
+    db_purge_users_wishlist(author_discord_id)
+
+    # Get all the users and the badgenames that want badges that the user has
+    inventory_matches = db_get_wishlist_inventory_matches(author_discord_id)
+    inventory_aggregate = {}
+    if inventory_matches:
+      for match in inventory_matches:
+        user_id = int(match['user_discord_id'])
+        if user_id == author_discord_id or user_id not in badge_trader_ids:
+          continue
+
+        user_record = inventory_aggregate.get(user_id)
+        if not user_record:
+          inventory_aggregate[user_id] = [match]
+        else:
+          inventory_aggregate[user_id].append(match)
+
+    if len(inventory_aggregate.keys()):
+      for user_id in inventory_aggregate.keys():
+        user = await bot.current_guild.fetch_member(user_id)
+
+        wants_badges = inventory_aggregate[user_id]
+        wants_badges = sorted(wants_badges, key=lambda b: b['badge_name'])
+
+        max_badges_per_page = 30
+
+        # Pages for Badges Match Wants
+        all_wants_pages = [wants_badges[i:i + max_badges_per_page] for i in range(0, len(wants_badges), max_badges_per_page)]
+        total_wants_pages = len(all_wants_pages)
+
+        wants_pages = []
+        for page_index, page_badges in enumerate(all_wants_pages):
+          embed = discord.Embed(
+            title=f"You Possess The Following From {user.display_name}'s Wishlist",
+            description=f"{user.mention} may be interested in the following from your Unlocked Inventory:\n"  + "\n".join([f"* [{b['badge_name']}]({b['badge_url']})" for b in page_badges]),
+            color=discord.Color.blurple()
+          )
+          embed.set_footer(text=f"Page {page_index + 1} of {total_wants_pages}")
+          wants_pages.append(embed)
+
+        paginator = WishlistPaginator(
+          pages=wants_pages,
+          show_menu=True,
+          custom_buttons=paginator_buttons,
+          use_default_buttons=False
+        )
+        await paginator.respond(ctx.interaction, ephemeral=True)
+    else:
+      await ctx.followup.send(
+        embed=discord.Embed(
+          title="No Traders Found",
+          description="Unable to find any Traders who are interested in items from your unlocked inventory.\n\nPlease try again later!",
+          color=discord.Color.blurple()
+        ), ephemeral=True
+      )
+
+    await initial_followup.delete()
+
+
   #    _____       .___  .___
   #   /  _  \    __| _/__| _/
   #  /  /_\  \  / __ |/ __ |

--- a/cogs/wishlist.py
+++ b/cogs/wishlist.py
@@ -704,7 +704,7 @@ class Wishlist(commands.Cog):
 
     # Get list of badge trader userids, we'll filter out any matches that don't have the role
     badge_trader_role = discord.utils.get(bot.current_guild.roles, name=config['roles']['badge_traders'])
-    badge_trader_ids = [m['id'] for m in badge_trader_role.members]
+    badge_trader_ids = [m.id for m in badge_trader_role.members]
 
     # Housekeeping
     # Clear any badges from the users wishlist that the user may already possess currently
@@ -741,19 +741,22 @@ class Wishlist(commands.Cog):
         wants_pages = []
         for page_index, page_badges in enumerate(all_wants_pages):
           embed = discord.Embed(
-            title=f"You Possess The Following From {user.display_name}'s Wishlist",
-            description=f"{user.mention} may be interested in the following from your Unlocked Inventory:\n"  + "\n".join([f"* [{b['badge_name']}]({b['badge_url']})" for b in page_badges]),
+            title=f"Found: {user.display_name}",
+            description=f"You possess Unlocked Badges that are on {user.mention}'s wishlist.\n\nThey may be interested in obtaining the following:\n"  + "\n".join([f"* [{b['badge_name']}]({b['badge_url']})" for b in page_badges]),
             color=discord.Color.blurple()
           )
           embed.set_footer(text=f"Page {page_index + 1} of {total_wants_pages}")
           wants_pages.append(embed)
 
-        paginator = WishlistPaginator(
+        paginator = pages.Paginator(
+          author_check=False,
           pages=wants_pages,
-          show_menu=True,
+          loop_pages=True,
           custom_buttons=paginator_buttons,
-          use_default_buttons=False
+          use_default_buttons=False,
+          disable_on_timeout=True
         )
+
         await paginator.respond(ctx.interaction, ephemeral=True)
     else:
       await ctx.followup.send(

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -938,15 +938,34 @@ async def badge_lookup(ctx:discord.ApplicationContext, public:str, name:str):
   description += f"Total number collected on The USS Hood: **{badge_count}**\n\n"
   description += f"{badge['badge_url']}"
 
+  # Badge Status For User
+  user_discord_id = ctx.author.id
+  user_badges = db_get_user_badges(user_discord_id)
+  if name in [b['badge_name'] for b in user_badges]:
+    locked_status = db_get_badge_locked_status_by_name(user_discord_id, name)
+    if locked_status['locked']:
+      badge_status = "Locked"
+    else:
+      badge_status = "Unlocked"
+  else:
+    wishlist_badges = db_get_user_wishlist_badges(user_discord_id)
+    if name in [b['badge_name'] for b in wishlist_badges]:
+      badge_status = "Wishlisted"
+    else:
+      badge_status = "Unowned"
+
   embed = discord.Embed(
     title=f"{badge['badge_name']}",
     description=description,
     color=discord.Color.random() # jp00p made me do it
   )
+  embed.add_field(
+    name=f"Badge Status for {ctx.author.display_name}",
+    value=f"* {badge_status}"
+  )
   discord_image = discord.File(fp=f"./images/badges/{badge['badge_filename']}", filename=badge['badge_filename'].replace(',','_'))
   embed.set_image(url=f"attachment://{badge['badge_filename'].replace(',','_')}")
   await ctx.followup.send(embed=embed, file=discord_image, ephemeral=not public)
-
 
 #   _________ __          __  .__          __  .__
 #  /   _____//  |______ _/  |_|__| _______/  |_|__| ____   ______

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -909,7 +909,7 @@ async def badge_lookup(ctx:discord.ApplicationContext, public:str, name:str):
     await ctx.followup.send(
       embed=discord.Embed(
         title="Could Not Find This Badge",
-        description=f"**{name}** does not appear to exist",
+        description=f"**{name}** does not appear to exist!",
         color=discord.Color.red()
       ), ephemeral=True
     )
@@ -938,30 +938,10 @@ async def badge_lookup(ctx:discord.ApplicationContext, public:str, name:str):
   description += f"Total number collected on The USS Hood: **{badge_count}**\n\n"
   description += f"{badge['badge_url']}"
 
-  # Badge Status For User
-  user_discord_id = ctx.author.id
-  user_badges = db_get_user_badges(user_discord_id)
-  if name in [b['badge_name'] for b in user_badges]:
-    locked_status = db_get_badge_locked_status_by_name(user_discord_id, name)
-    if locked_status['locked']:
-      badge_status = "Locked"
-    else:
-      badge_status = "Unlocked"
-  else:
-    wishlist_badges = db_get_user_wishlist_badges(user_discord_id)
-    if name in [b['badge_name'] for b in wishlist_badges]:
-      badge_status = "Wishlisted"
-    else:
-      badge_status = "Unowned"
-
   embed = discord.Embed(
     title=f"{badge['badge_name']}",
     description=description,
     color=discord.Color.random() # jp00p made me do it
-  )
-  embed.add_field(
-    name=f"Badge Status for {ctx.author.display_name}",
-    value=f"* {badge_status}"
   )
   discord_image = discord.File(fp=f"./images/badges/{badge['badge_filename']}", filename=badge['badge_filename'].replace(',','_'))
   embed.set_image(url=f"attachment://{badge['badge_filename'].replace(',','_')}")
@@ -1002,6 +982,58 @@ async def badge_statistics(ctx:discord.ApplicationContext):
   embed.add_field(name=f"{get_emoji('combadge')} Top 5 most locked", value=str("\n".join(f"{t['badge_name']} ({t['count']})" for t in top_locked)), inline=True)
   await ctx.respond(embed=embed, ephemeral=False)
 
+
+@badge_group.command(
+  name="status",
+  description="Get the status of a specific badge w/r/t your inventory"
+)
+@option(
+  name="name",
+  description="Which badge do you want to check the status of?",
+  required=True,
+  autocomplete=all_badges_autocomplete
+)
+async def badge_status(ctx:discord.ApplicationContext, name:str):
+  await ctx.defer(ephemeral=True)
+  user_discord_id = ctx.author.id
+
+  logger.info(f"{Fore.CYAN}Firing /badge status command for {ctx.author.display_name} w/r/t '{name}'!{Fore.RESET}")
+
+  if name not in [b['badge_name'] for b in all_badge_info]:
+    await ctx.followup.send(
+      embed=discord.Embed(
+        title="Could Not Find This Badge",
+        description=f"**{name}** does not appear to exist!",
+        color=discord.Color.red()
+      ), ephemeral=True
+    )
+    return
+
+  badge_info = db_get_badge_info_by_name(name)
+
+  user_badges = db_get_user_badges(user_discord_id)
+  if name in [b['badge_name'] for b in user_badges]:
+    locked_status = db_get_badge_locked_status_by_name(user_discord_id, name)
+    if locked_status['locked']:
+      badge_status = "Locked"
+    else:
+      badge_status = "Unlocked"
+  else:
+    wishlist_badges = db_get_user_wishlist_badges(user_discord_id)
+    if name in [b['badge_name'] for b in wishlist_badges]:
+      badge_status = "Wishlisted"
+    else:
+      badge_status = "Not Owned"
+
+  embed = discord.Embed(
+    title=f"STATUS: {badge_info['badge_name']}",
+    description=badge_status,
+    color=discord.Color.blurple()
+  )
+  discord_image = discord.File(fp=f"./images/badges/{badge_info['badge_filename']}", filename=badge_info['badge_filename'].replace(',','_'))
+  embed.set_image(url=f"attachment://{badge_info['badge_filename'].replace(',','_')}")
+  embed.set_footer(text="Status will be one of: `Locked`, `Unlocked`, `Wishlisted` or `Not Owned`")
+  await ctx.followup.send(embed=embed, file=discord_image, ephemeral=True)
 
 #   ________.__  _____  __
 #  /  _____/|__|/ ____\/  |_

--- a/commands/badges.py
+++ b/commands/badges.py
@@ -1026,8 +1026,8 @@ async def badge_status(ctx:discord.ApplicationContext, name:str):
       badge_status = "Not Owned"
 
   embed = discord.Embed(
-    title=f"STATUS: {badge_info['badge_name']}",
-    description=badge_status,
+    title=badge_info['badge_name'],
+    description=f"Status: **{badge_status}**",
     color=discord.Color.blurple()
   )
   discord_image = discord.File(fp=f"./images/badges/{badge_info['badge_filename']}", filename=badge_info['badge_filename'].replace(',','_'))

--- a/commands/q.py
+++ b/commands/q.py
@@ -52,7 +52,7 @@ async def display_user(user_id, ctx):
   user_columns = json.load(f)
   f.close()
   user_data = get_user(user_id)
-  #logger.debug(f"this_user: {user_data}")
+  logger.info(f"q data: {user_data}")
 
   user = await bot.fetch_user(user_id)
   embed = discord.Embed()

--- a/configuration.json
+++ b/configuration.json
@@ -616,7 +616,7 @@
     "qget": {
       "channels": [
         "robot-diagnostics",
-        "mclaughlin-group"
+        "code-47"
       ],
       "enabled": true,
       "data": "data/user-info.json",
@@ -624,7 +624,7 @@
     },
     "qset": {
       "channels": [
-        "robot-diagnostics"
+        "code-47"
       ],
       "enabled": true,
       "data": null,

--- a/configuration.json
+++ b/configuration.json
@@ -402,6 +402,14 @@
       "enabled": true,
       "parameters": []
     },
+    "badges status": {
+      "channels": [
+        "badgeys-badges",
+        "bahrats-bazaar"
+      ],
+      "enabled": true,
+      "parameters": []
+    },
     "badges scrap": {
       "channels": [
         "badgeys-badges",

--- a/configuration.json
+++ b/configuration.json
@@ -961,6 +961,15 @@
       "data": null,
       "parameters": []
     },
+    "wishlist find_traders": {
+      "channels": [
+        "badgeys-badges",
+        "bahrats-bazaar"
+      ],
+      "enabled": true,
+      "data": null,
+      "parameters": []
+    },
     "wishlist matches": {
       "channels": [
         "badgeys-badges",
@@ -1024,6 +1033,7 @@
   "role_map": {},
   "roles": {
     "agimus_maintainers": "AGIMUS Acolyte",
+    "badge_traders": "Badge Trader",
     "shimoda_pollsters": "T'Pollsters",
     "reaction_roles_enabled": true,
     "promotion_roles": {


### PR DESCRIPTION
## `/badges status`
Requested feature that will just report back to the user whether a badge is:
`Locked`, `Unlocked`, `Wishlisted` or `Not Owned`

## `/wishlist find_traders`
Kind of a partial `/wishlist matches` but it is limited to those with the `@Badge Trader` role and only displays badges that _YOU_ possess that they might be interested in acquiring.

Intended to prompt some more trading by having people make inquiries for what the other party might be willing to offer.