### PR TITLE
Paginate Continuum Lists for Big Tongo Games

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v2.7.4
-appVersion: v2.7.4
+version: v2.7.5
+appVersion: v2.7.5

--- a/cogs/tongo.py
+++ b/cogs/tongo.py
@@ -177,6 +177,7 @@ class Tongo(commands.Cog):
     await self._cancel_tongo_related_trades(user_discord_id, selected_user_badges)
 
     tongo_pot_badges = db_get_tongo_pot_badges()
+    tongo_pot_chunks = [tongo_pot_badges[i:i + 30] for i in range(0, len(tongo_pot_badges), 30)]
 
     confirmation_embed = discord.Embed(
       title="TONGO! Badges Ventured!",
@@ -193,7 +194,7 @@ class Tongo(commands.Cog):
     )
     confirmation_embed.add_field(
       name=f"The Great Material Continuum",
-      value="\n".join([f"* {b['badge_name']}" for b in tongo_pot_badges]),
+      value="\n".join([f"* {b['badge_name']}" for b in tongo_pot_chunks[0]]),
       inline=False
     )
     confirmation_embed.set_image(url="https://i.imgur.com/tRi1vYq.gif")
@@ -205,6 +206,23 @@ class Tongo(commands.Cog):
     continuum_images = await generate_paginated_continuum_images(tongo_pot_badges)
     trade_channel = await self.bot.fetch_channel(get_channel_id("bahrats-bazaar"))
     await trade_channel.send(embed=confirmation_embed)
+
+    if len(tongo_pot_chunks) > 1:
+      for t_chunk in tongo_pot_chunks[1:]:
+        chunk_embed = discord.Embed(
+          title=f"TONGO! Badges Ventured by **{user_member.display_name}** (Continued)!"
+        )
+        chunk_embed.add_field(
+          name=f"Total Badges In The Great Material Continuum!",
+          value="\n".join([f"* {b['badge_name']}" for b in t_chunk]),
+          inline=False
+        )
+        chunk_embed.set_footer(
+          text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}",
+          icon_url="https://i.imgur.com/GTN4gQG.jpg"
+        )
+        await trade_channel.send(embed=chunk_embed)
+
     await self._send_continuum_images_to_channel(trade_channel, continuum_images)
 
     self.first_auto_confront = True
@@ -496,6 +514,7 @@ class Tongo(commands.Cog):
     tongo_player_members = [await self.bot.current_guild.fetch_member(id) for id in tongo_player_ids]
 
     tongo_pot_badges = db_get_tongo_pot_badges()
+    tongo_pot_chunks = [tongo_pot_badges[i:i + 30] for i in range(0, len(tongo_pot_badges), 30)]
 
     description=f"Index requested by **{user_member.display_name}**!\n\nDisplaying the status of the current game of Tongo!\n\n"
     if self.auto_confront.next_iteration:
@@ -520,7 +539,7 @@ class Tongo(commands.Cog):
     )
     confirmation_embed.add_field(
       name=f"Total Badges In The Great Material Continuum!",
-      value="\n".join([f"* {b['badge_name']}" for b in tongo_pot_badges]),
+      value="\n".join([f"* {b['badge_name']}" for b in tongo_pot_chunks[0]]),
       inline=False
     )
     confirmation_embed.set_image(url="https://i.imgur.com/aWLYGKQ.gif")
@@ -531,6 +550,23 @@ class Tongo(commands.Cog):
     continuum_images = await generate_paginated_continuum_images(tongo_pot_badges)
     trade_channel = await self.bot.fetch_channel(get_channel_id("bahrats-bazaar"))
     await trade_channel.send(embed=confirmation_embed)
+
+    if len(tongo_pot_chunks) > 1:
+      for t_chunk in tongo_pot_chunks[1:]:
+        chunk_embed = discord.Embed(
+          title=f"Index requested by **{user_member.display_name}** (Continued)"
+        )
+        chunk_embed.add_field(
+          name=f"Total Badges In The Great Material Continuum!",
+          value="\n".join([f"* {b['badge_name']}" for b in t_chunk]),
+          inline=False
+        )
+        chunk_embed.set_footer(
+          text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}",
+          icon_url="https://i.imgur.com/GTN4gQG.jpg"
+        )
+        await trade_channel.send(embed=chunk_embed)
+
     await self._send_continuum_images_to_channel(trade_channel, continuum_images)
 
   async def _send_continuum_images_to_channel(self, trade_channel, continuum_images):

--- a/commands/xpinfo.py
+++ b/commands/xpinfo.py
@@ -97,7 +97,7 @@ async def xpinfo_channels(ctx:discord.ApplicationContext, public:str):
   discord_image = discord.File(filepath_and_filename[0], filename=filepath_and_filename[1])
   embed = discord.Embed(
     title="INFO - Top Channels",
-    description=f"{user_member.mention}'s Top 5",
+    description=f"{user_member.mention}'s Top 5 (90-Day XP Activity)",
     color=discord.Color.red()
   )
   embed.add_field(
@@ -108,7 +108,7 @@ async def xpinfo_channels(ctx:discord.ApplicationContext, public:str):
     inline=False
   )
   embed.set_image(url=f"attachment://{discord_image.filename}")
-  embed.set_footer(text=f"{sum(values)} total messages analyzed over the past 90 days.")
+  embed.set_footer(text=f"{sum(values)} total messages analyzed over the past 90 days.\nUse /xpinfo to generate your own!")
   if public:
     await ctx.followup.send(embed=discord.Embed(title="Info Sent To Channel!", color=discord.Color.blurple()))
     await ctx.channel.send(embed=embed, file=discord_image)
@@ -279,7 +279,7 @@ async def xpinfo_activity(ctx:discord.ApplicationContext, public:str):
   discord_image = discord.File(filepath_and_filename[0], filename=filepath_and_filename[1])
   embed = discord.Embed(
     title="INFO - XP Activity",
-    description=f"{user_member.mention}'s 30-Day XP Activity",
+    description=f"{user_member.mention}'s Graphed Daily Totals (30-Day XP Activity)",
     color=discord.Color.red()
   )
   embed.add_field(
@@ -296,7 +296,8 @@ async def xpinfo_activity(ctx:discord.ApplicationContext, public:str):
   embed.set_footer(
     text=f"{total_actions} total actions analyzed over the past 30 days.\n"
           "Includes all XP actions i.e. Posts, Reacts, Bot Games, etc.\n"
-          "Dates given are in `US/Pacific` time."
+          "Dates given are in `US/Pacific` time.\n"
+          "Use /xpinfo to generate your own!"
   )
   if public:
     await ctx.followup.send(embed=discord.Embed(title="Info Sent To Channel!", color=discord.Color.blurple()))


### PR DESCRIPTION
Ran into an issue recently where a biiiiiig tongo game hit the 1024 character limit for the 'Total Badges In Material Continuum' field. This fixes that.

Also added a little text to the xpinfo footers to let other users know how to generate their own.