### PR TITLE
Increase max_trades from 3 to 10

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v2.10.3
-appVersion: v2.10.3
+version: v2.10.4
+appVersion: v2.10.4

--- a/cogs/trade.py
+++ b/cogs/trade.py
@@ -213,7 +213,7 @@ class Trade(commands.Cog):
   def __init__(self, bot):
     self.bot = bot
     # We only allow requestees to have n trades pending for managability's sake
-    self.max_trades = 3
+    self.max_trades = 10
     self.max_badges_per_trade = 6
     self.trade_buttons = [
       pages.PaginatorButton("prev", label="    ⬅     ", style=discord.ButtonStyle.primary, row=1),


### PR DESCRIPTION
Ehhhh, why not.

Shoup is going to trade away ALL of his badges when he hits level 500 so let's make things slightly more managable for him? Maybe this will blow something up, but if 3 was working I don't see why 10 wouldn't.

WHEE!