### PR TITLE
Resume Tongo with on_ready

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v2.11.18
-appVersion: v2.11.18
+version: v2.11.19
+appVersion: v2.11.19

--- a/cogs/tongo.py
+++ b/cogs/tongo.py
@@ -57,9 +57,59 @@ class Tongo(commands.Cog):
       ),
       pages.PaginatorButton("next", label="     ➡    ", style=discord.ButtonStyle.primary, row=1),
     ]
-    self.first_auto_confront = True
 
   tongo = discord.SlashCommandGroup("tongo", "Commands for Tongo Badge Game")
+
+  #   _    _    _
+  #  | |  (_)__| |_ ___ _ _  ___ _ _ ___
+  #  | |__| (_-<  _/ -_) ' \/ -_) '_(_-<
+  #  |____|_/__/\__\___|_||_\___|_| /__/
+  @commands.Cog.listener()
+  async def on_ready(self):
+    # If bot restarts, resume the Tongoening
+    active_tongo = await db_get_active_tongo()
+    if active_tongo:
+      active_tongo_chair_id = int(active_tongo['chair_discord_id'])
+      active_chair = await self.bot.current_guild.fetch_member(active_tongo_chair_id)
+      trade_channel = await self.bot.fetch_channel(get_channel_id("bahrats-bazaar"))
+
+      time_created = active_tongo['time_created']
+      elapsed_time = (datetime.now(timezone.utc) - time_created).total_seconds()
+      remaining_time = max(0, 8 * 3600 - elapsed_time)  # 8 hours in seconds
+
+      if remaining_time > 0:
+        self.auto_confront.change_interval(seconds=remaining_time)
+        self.auto_confront.start()
+
+        reboot_embed = discord.Embed(
+          title="REBOOT DETECTED! Resuming Tongo...",
+          description="***Rude!*** We had a game in progress!\n\n"
+                      f"The current game chaired by {active_chair.display_name} has been resumed.\n\n"
+                      f"This Tongo game has {humanize.naturaltime(remaining_time)} left before the game is automatically ended!",
+          color=discord.Color.red()
+        )
+        reboot_embed.set_image(url="https://i.imgur.com/K4hUjh6.gif")
+        reboot_embed.set_footer(
+          text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}",
+          icon_url="https://i.imgur.com/GTN4gQG.jpg"
+        )
+        await trade_channel.send(embed=reboot_embed)
+      else:
+        # If time has already passed, trigger auto-confront immediately
+        downtime_embed = discord.Embed(
+          title="DOWNTIME DETECTED! Auto-confronting Tongo...",
+          description="**Heywaitaminute!!!**\n\n"
+                      f"Just woke up and noticed that the previous game chaired by {active_chair.display_name} never ended on time!\n\n"
+                      "Since the time has elapsed, confronting now! 👉👈",
+          color=discord.Color.red()
+        )
+        downtime_embed.set_image(url="https://i.imgur.com/K4hUjh6.gif")
+        downtime_embed.set_footer(
+          text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}",
+          icon_url="https://i.imgur.com/GTN4gQG.jpg"
+        )
+        await trade_channel.send(embed=reboot_embed)
+        await self._perform_confront(active_tongo, active_tongo['chair_discord_id'], auto_confront=True)
 
   #   _   __         __
   #  | | / /__ ___  / /___ _________
@@ -227,7 +277,7 @@ class Tongo(commands.Cog):
 
     await self._send_continuum_images_to_channel(trade_channel, continuum_images)
 
-    self.first_auto_confront = True
+    self.auto_confront.change_interval(hours=8)
     self.auto_confront.start()
 
   #    ___  _     __
@@ -673,10 +723,6 @@ class Tongo(commands.Cog):
   # /_/ |_\_,_/\__/\___/    \___/\___/_//_/_//_/  \___/_//_/\__/
   @tasks.loop(hours=8)
   async def auto_confront(self):
-    if self.first_auto_confront:
-      self.first_auto_confront = False
-      return
-
     active_tongo = await db_get_active_tongo()
 
     if not active_tongo:

--- a/cogs/tongo.py
+++ b/cogs/tongo.py
@@ -57,6 +57,7 @@ class Tongo(commands.Cog):
       ),
       pages.PaginatorButton("next", label="     ➡    ", style=discord.ButtonStyle.primary, row=1),
     ]
+    self.first_auto_confront = True
 
   tongo = discord.SlashCommandGroup("tongo", "Commands for Tongo Badge Game")
 
@@ -74,18 +75,23 @@ class Tongo(commands.Cog):
       trade_channel = await self.bot.fetch_channel(get_channel_id("bahrats-bazaar"))
 
       time_created = active_tongo['time_created']
-      elapsed_time = (datetime.now(timezone.utc) - time_created).total_seconds()
+      time_created = time_created.replace(tzinfo=timezone.utc)
+
+      current_time = datetime.now(timezone.utc)
+      elapsed_time = (current_time - time_created).total_seconds()
       remaining_time = max(0, 8 * 3600 - elapsed_time)  # 8 hours in seconds
 
       if remaining_time > 0:
         self.auto_confront.change_interval(seconds=remaining_time)
+        self.first_auto_confront = True
         self.auto_confront.start()
 
+        time_left = current_time + timedelta(seconds=remaining_time)
         reboot_embed = discord.Embed(
           title="REBOOT DETECTED! Resuming Tongo...",
-          description="***Rude!*** We had a game in progress!\n\n"
+          description="We had a game in progress! ***Rude!***\n\n"
                       f"The current game chaired by {active_chair.display_name} has been resumed.\n\n"
-                      f"This Tongo game has {humanize.naturaltime(remaining_time)} left before the game is automatically ended!",
+                      f"This Tongo game has {humanize.naturaltime(time_left)} left before the game is automatically ended!",
           color=discord.Color.red()
         )
         reboot_embed.set_image(url="https://i.imgur.com/K4hUjh6.gif")
@@ -98,18 +104,17 @@ class Tongo(commands.Cog):
         # If time has already passed, trigger auto-confront immediately
         downtime_embed = discord.Embed(
           title="DOWNTIME DETECTED! Auto-confronting Tongo...",
-          description="**Heywaitaminute!!!**\n\n"
-                      f"Just woke up and noticed that the previous game chaired by {active_chair.display_name} never ended on time!\n\n"
+          description=f"**Heywaitaminute!!!** Just woke up and noticed that the previous game chaired by {active_chair.display_name} never ended on time!\n\n"
                       "Since the time has elapsed, confronting now! 👉👈",
           color=discord.Color.red()
         )
-        downtime_embed.set_image(url="https://i.imgur.com/K4hUjh6.gif")
+        downtime_embed.set_image(url="https://i.imgur.com/t5dZu6O.gif")
         downtime_embed.set_footer(
           text=f"Ferengi Rule of Acquisition {random.choice(rules_of_acquisition)}",
           icon_url="https://i.imgur.com/GTN4gQG.jpg"
         )
-        await trade_channel.send(embed=reboot_embed)
-        await self._perform_confront(active_tongo, active_tongo['chair_discord_id'], auto_confront=True)
+        await trade_channel.send(embed=downtime_embed)
+        await self._perform_confront(active_tongo, active_chair, auto_confront=True)
 
   #   _   __         __
   #  | | / /__ ___  / /___ _________
@@ -278,6 +283,7 @@ class Tongo(commands.Cog):
     await self._send_continuum_images_to_channel(trade_channel, continuum_images)
 
     self.auto_confront.change_interval(hours=8)
+    self.first_auto_confront = True
     self.auto_confront.start()
 
   #    ___  _     __
@@ -723,6 +729,10 @@ class Tongo(commands.Cog):
   # /_/ |_\_,_/\__/\___/    \___/\___/_//_/_//_/  \___/_//_/\__/
   @tasks.loop(hours=8)
   async def auto_confront(self):
+    if self.first_auto_confront:
+      self.first_auto_confront = False
+      return
+
     active_tongo = await db_get_active_tongo()
 
     if not active_tongo:

--- a/cogs/tongo.py
+++ b/cogs/tongo.py
@@ -90,7 +90,7 @@ class Tongo(commands.Cog):
         reboot_embed = discord.Embed(
           title="REBOOT DETECTED! Resuming Tongo...",
           description="We had a game in progress! ***Rude!***\n\n"
-                      f"The current game chaired by {active_chair.display_name} has been resumed.\n\n"
+                      f"The current game chaired by **{active_chair.display_name}** has been resumed.\n\n"
                       f"This Tongo game has {humanize.naturaltime(time_left)} left before the game is automatically ended!",
           color=discord.Color.red()
         )
@@ -104,7 +104,7 @@ class Tongo(commands.Cog):
         # If time has already passed, trigger auto-confront immediately
         downtime_embed = discord.Embed(
           title="DOWNTIME DETECTED! Auto-confronting Tongo...",
-          description=f"**Heywaitaminute!!!** Just woke up and noticed that the previous game chaired by {active_chair.display_name} never ended on time!\n\n"
+          description=f"**Heywaitaminute!!!** Just woke up and noticed that the previous game chaired by **{active_chair.display_name}** never ended on time!\n\n"
                       "Since the time has elapsed, confronting now! 👉👈",
           color=discord.Color.red()
         )


### PR DESCRIPTION
Aggy gets restarted periodically (often when we roll out updates) and the timer for the Tongo auto-confront is lost. Throwing some stuff into on_ready() so that it figures out how to resume the game.