### PR TITLE
Repair Missing Level-Up Badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ local.json
 /local_*.json
 *dump.sql
 *sql.gz
+agimus.sql-*
 
 # Pyre type checker
 .pyre/

--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v3.3.3
-appVersion: v3.3.3
+version: v3.3.4
+appVersion: v3.3.4

--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v3.3.4
-appVersion: v3.3.4
+version: v3.4.0
+appVersion: v3.4.0

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -419,6 +419,7 @@ class Admin(commands.Cog):
           total_badges_granted += 1
         total_users_fixed += 1
       except Exception as e:
+        logger.info(f"Error: Problem with `repair_missing_levelup_badges` for {user_id}", exc_info=True)
         failed.append(user_id)
 
     summary = discord.Embed(

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -12,6 +12,7 @@ from utils.badge_instances import *
 from utils.crystal_effects import *
 from utils.echelon_rewards import *
 from utils.prestige import PRESTIGE_TIERS
+from utils.settings_utils import db_get_current_xp_enabled_value
 
 from utils.check_user_access import user_check
 
@@ -389,6 +390,10 @@ class Admin(commands.Cog):
     for row in users:
       user_id = row['user_discord_id']
       expected = row['current_level']
+
+      xp_enabled = bool(await db_get_current_xp_enabled_value(user_id))
+      if not xp_enabled:
+        continue
 
       actual = await db_get_levelup_badge_count(user_id)
       missing = expected - actual

--- a/configuration.json
+++ b/configuration.json
@@ -1162,7 +1162,12 @@
       "enabled": true,
       "parameters": []
     },
-    "zed_ops repair_levels" {
+    "zed_ops repair_levels": {
+      "allowed_user_ids": [735658100958298154],
+      "enabled": true,
+      "parameters": []
+    },
+    "zed_ops repair_levelup_badges": {
       "allowed_user_ids": [735658100958298154],
       "enabled": true,
       "parameters": []

--- a/data/level_up_messages.json
+++ b/data/level_up_messages.json
@@ -39,7 +39,7 @@
     "Holy fuckin shit, {user} just reached Echelon {level}! Look at this badge!!!",
     "It's good to see {user} level up to Echelon {level} in the server today.",
     "{user} is on the move! Echelon {level} and no end in sight!",
-    "Okay, so {user} got to Echelon {level}. Does that impressa me much? It does actually.",
+    "Okay, so {user} got to Echelon {level}. Does that impress me much? It does actually.",
     "Do you smell that? Smells like {user} just got to Echelon {level}!",
     "How much XP does it take to get to Echelon {level}? Just ask {user} cuz they have leveled up!",
     "Everybody please look at {user} -- they just got to Echelon {level}!",

--- a/data/schema.sql
+++ b/data/schema.sql
@@ -444,16 +444,17 @@ CREATE TABLE IF NOT EXISTS crystal_ranks (
   name VARCHAR(64) NOT NULL UNIQUE,
   emoji VARCHAR(16),
   rarity_rank INT NOT NULL,
-  drop_chance DECIMAL(5,2) NOT NULL,
+  drop_chance FLOAT NOT NULL,
   sort_order INT DEFAULT 0
 );
 
 INSERT INTO crystal_ranks (name, emoji, rarity_rank, drop_chance, sort_order) VALUES
-  ("Common",    "⚪", 1, 50, 0),
-  ("Uncommon",  "🟢", 2, 33, 1),
-  ("Rare",      "🟣", 3, 10, 2),
-  ("Legendary", "🔥", 4, 5, 3),
-  ("Mythic",    "💎", 5, 2, 4);
+  ("Common",      "⚪", 1, 50,   0),
+  ("Uncommon",    "🟢", 2, 33,   1),
+  ("Rare",        "🟣", 3, 10,   2),
+  ("Legendary",   "🔥", 4, 5,    3),
+  ("Mythic",      "💎", 5, 1.75, 4),
+  ("Unobtainium", "💥", 6, 0.25,  5);
 
 -- Crystal Types
 CREATE TABLE IF NOT EXISTS crystal_types (
@@ -516,7 +517,10 @@ INSERT INTO crystal_types (name, rarity_rank, icon, effect, description) VALUES
   -- Mythic Crystals (Prestige Animations)
   ("Borg Nanocluster", 5, "borg_nanocluster.png", "borg_reconstruction", "A Collective collectable. Reconstructs whatever it touches (whether it wants to or not)."),
   ("Bajoran Orb", 5, "bajoran_orb.png", "celestial_temple", "A Tear of the Prophets. My Child!"),
-  ("Omega Molecule", 5, "omega.png", "shimmer_flux", "The perfect form of matter. Dangerous, beautiful, and rarely stable.");
+  ("Omega Molecule", 5, "omega.png", "shimmer_flux", "The perfect form of matter. Dangerous, beautiful, and rarely stable."),
+
+  -- Unobtanium Crystals (Complex Animations + Coveted Designs)
+  ("Bone Fragment", 6, "bone_fragment.png", "moopsy_swarm", "That's bone. Looks oddly drinkable.");
 
 -- Crystal Pattern Buffers (Credits to redeem for Crystals)
 CREATE TABLE IF NOT EXISTS crystal_pattern_buffers (

--- a/handlers/echelon_xp.py
+++ b/handlers/echelon_xp.py
@@ -259,7 +259,7 @@ async def post_buffer_pattern_acquired_embed(member: discord.Member, level: int,
   else:
     embed = discord.Embed(
       title="Crystal Pattern Buffers Acquired!",
-      description=f"{member.mention} materialized onto the transporter pad with **{number_of_patterns} Crystal Pattern Buffers** in their hands when they reached Echelon {level}!\n\n"
+      description=f"{member.mention} materialized onto the transporter pad with **{number_of_patterns} Crystal Pattern Buffers** in their hands{level_text}!\n\n"
                   f"They can now use them to replicate **{number_of_patterns}** Crystals from scratch over in {gelrak_v.mention}!",
       color=discord.Color.teal()
     )

--- a/handlers/echelon_xp.py
+++ b/handlers/echelon_xp.py
@@ -246,7 +246,7 @@ async def post_buffer_pattern_acquired_embed(member: discord.Member, level: int,
   gelrak_v = await bot.fetch_channel(get_channel_id("gelrak-v"))
 
   embed = None
-  if number_of_patterns == 1:
+  if number_of_patterns == 1 and level > 1:
     level_text = ""
     if level > 0:
       level_text = f" when they reached Echelon {level}"
@@ -259,7 +259,7 @@ async def post_buffer_pattern_acquired_embed(member: discord.Member, level: int,
   else:
     embed = discord.Embed(
       title="Crystal Pattern Buffers Acquired!",
-      description=f"{member.mention} materialized onto the transporter pad with **{number_of_patterns} Crystal Pattern Buffers** in their hands{level_text}!\n\n"
+      description=f"{member.mention} materialized onto the transporter pad with **{number_of_patterns} Crystal Pattern Buffers** in their hands when they reached Echelon {level}!\n\n"
                   f"They can now use them to replicate **{number_of_patterns}** Crystals from scratch over in {gelrak_v.mention}!",
       color=discord.Color.teal()
     )
@@ -309,7 +309,7 @@ async def post_badge_repair_embed(member: discord.User, badge_data: dict):
 
   discord_file, attachment_url = await generate_badge_preview(member.id, badge_data, theme='teal')
 
-  embed_description = f"{member.mention}'s inventory has been corrected with a {PRESTIGE_TIERS[badge_prestige]} Tier **Badge Correction**, which they were previously owned but had not yet been granted."
+  embed_description = f"{member.mention}'s inventory has been corrected with a {PRESTIGE_TIERS[badge_prestige]} Tier **Badge Correction**, which they had previously earned during `AGIMUS Downtime` but had not yet been granted."
   if badge_data.get('was_on_wishlist', False):
     embed_description += f"\n\nIt was also on their ✨ **wishlist** ✨! {get_emoji('picard_yes_happy_celebrate')}"
 

--- a/handlers/echelon_xp.py
+++ b/handlers/echelon_xp.py
@@ -247,9 +247,13 @@ async def post_buffer_pattern_acquired_embed(member: discord.Member, level: int,
 
   embed = None
   if number_of_patterns == 1:
+    level_text = ""
+    if level > 0:
+      level_text = f" when they reached Echelon {level}"
+
     embed = discord.Embed(
       title="Crystal Pattern Buffer Acquired!",
-      description=f"{member.mention} {random.choice(BUFFER_PATTERN_AQUISITION_REASONS)} **Crystal Pattern Buffer** when they reached Echelon {level}!\n\nThey can now use it to replicate a Crystal from scratch over in {gelrak_v.mention}!",
+      description=f"{member.mention} {random.choice(BUFFER_PATTERN_AQUISITION_REASONS)} **Crystal Pattern Buffer**{level_text}!\n\nThey can now use it to replicate a Crystal from scratch over in {gelrak_v.mention}!",
       color=discord.Color.teal()
     )
   else:
@@ -293,6 +297,41 @@ BUFFER_PATTERN_AQUISITION_GIFS = [
   "https://i.imgur.com/RVEncra.gif",
   "https://i.imgur.com/O8FIb0I.gif"
 ]
+
+
+
+async def post_badge_repair_embed(member: discord.User, badge_data: dict):
+  """
+  Build and send a level-up notification embed to the XP notification channel.
+  """
+  badge_prestige = badge_data['prestige_level']
+  # level_up_msg = f"**{random.choice(random_level_up_messages['messages']).format(user=member.mention, level=level, prev_level=(level-1))}**"
+
+  discord_file, attachment_url = await generate_badge_preview(member.id, badge_data, theme='teal')
+
+  embed_description = f"{member.mention}'s inventory has been corrected with a {PRESTIGE_TIERS[badge_prestige]} Tier **Badge Correction**, which they were previously owned but had not yet been granted."
+  if badge_data.get('was_on_wishlist', False):
+    embed_description += f"\n\nIt was also on their ✨ **wishlist** ✨! {get_emoji('picard_yes_happy_celebrate')}"
+
+  embed_color = discord.Color.teal()
+  if badge_prestige > 0:
+    prestige_color = PRESTIGE_THEMES[badge_prestige]['primary']
+    embed_color = discord.Color.from_rgb(prestige_color[0], prestige_color[1], prestige_color[2])
+
+  embed=discord.Embed(
+    title="Badge Correction!",
+    description=embed_description,
+    color=embed_color
+  )
+  embed.set_image(url=attachment_url)
+  embed.set_thumbnail(url=random.choice(config["handlers"]["xp"]["celebration_images"]))
+  embed.add_field(name=badge_data['badge_name'], value=badge_data['badge_url'], inline=False)
+  embed.set_footer(text="See all your badges by typing '/badges collection' - disable this by typing '/settings'")
+
+  notification_channel = bot.get_channel(get_channel_id(config["handlers"]["xp"]["notification_channel"]))
+  message = await notification_channel.send(content=f"## {member.mention}: You've Received A Badge Correction", file=discord_file, embed=embed)
+  # Add + emoji so that users can add it as well to add the badge to their wishlist
+  await message.add_reaction("✅")
 
 # .____                      .__             ____ ___           ____ ___   __  .__.__
 # |    |    _______  __ ____ |  |           |    |   \______   |    |   \_/  |_|__|  |   ______

--- a/migrations/v3.4.0.sql
+++ b/migrations/v3.4.0.sql
@@ -1,0 +1,2 @@
+INSERT INTO crystal_types (name, rarity_rank, icon, effect, description) VALUES
+("Artificial Singularity", 4, "artificial_singularity.png", "singularity_warp", "Used by Romulans to power their Warbirds. This thing sucks!");

--- a/queries/badge_instances.py
+++ b/queries/badge_instances.py
@@ -333,6 +333,19 @@ async def db_get_badge_instances_prestige_count_by_filename(badge_filename: str)
     result = await query.fetchall()
   return result
 
+
+async def db_get_levelup_badge_count(user_id: str) -> int:
+  sql = """
+    SELECT COUNT(*) AS count
+    FROM badge_instance_history
+    WHERE to_user_id = %s AND event_type = 'level_up'
+  """
+  async with AgimusDB(dictionary=True) as db:
+    await db.execute(sql, (user_id,))
+    row = await db.fetchone()
+    return row['count']
+
+
 # Lock/Unlock Helpers
 async def db_lock_badge_instance(instance_id: int):
   async with AgimusDB() as db:

--- a/utils/echelon_rewards.py
+++ b/utils/echelon_rewards.py
@@ -128,9 +128,9 @@ async def select_badge_for_level_up(member: discord.Member) -> tuple[int, int]:
 
   base_missing_pct = len(base_missing) / total_count if total_count else 1
 
-  logger.info(
-    f"[echelon] PQIF Base Tier {pqif_base} -> {next_prestige} — base missing {len(base_missing)} / {total_count}, next missing {len(next_missing)}"
-  )
+  # logger.info(
+  #   f"[echelon] PQIF Base Tier {pqif_base} -> {next_prestige} — base missing {len(base_missing)} / {total_count}, next missing {len(next_missing)}"
+  # )
 
   candidates = []
 


### PR DESCRIPTION
During that last AGIMUS downtime we were still granting XP/Levels but the issue with the badge code was preventing the actual badges from being created which are owed to users.

This PR adds an admin command to determine how many badges they are owed (compares their current level to the number of "level_up" badge history events, which *should* be 1 to 1), and creates a new randomized badge for them and alerts them with a special embed.

Includes a migration because I snuck a new crystal in here!

`MIGRATION_FILE=./migrations/v3.4.0.sql make db-migrate`