### PR TITLE
`/badges unowned`

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v3.13.0
-appVersion: v3.13.0
+version: v3.13.1
+appVersion: v3.13.1

--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v3.12.3
-appVersion: v3.12.3
+version: v3.13.0
+appVersion: v3.13.0

--- a/cogs/badges.py
+++ b/cogs/badges.py
@@ -327,13 +327,14 @@ class Badges(commands.Cog):
       for color_choice in ["Green", "Orange", "Purple", "Teal"]
     ]
   )
+  @commands.check(access_check)
   async def unowned(self, ctx: discord.ApplicationContext, public: str, prestige: str, color: str = None):
-    logger.info(f"{ctx.author.display_name} is pulling up their {Style.BRIGHT}`/badges unowned`{Style.RESET_ALL} badges for their {Style.BRIGHT}{PRESTIGE_TIERS[prestige]}{Style.RESET_ALL} Tier!")
-
     if not await is_prestige_valid(ctx, prestige):
       return
     prestige = int(prestige)
     public = (public == "yes")
+
+    logger.info(f"{ctx.author.display_name} is pulling up their {Style.BRIGHT}`/badges unowned`{Style.RESET_ALL} badges for their {Style.BRIGHT}{PRESTIGE_TIERS[prestige]}{Style.RESET_ALL} Tier!")
 
     unowned_badges = await db_get_unowned_user_badge_instances(ctx.author.id, prestige)
 
@@ -360,7 +361,7 @@ class Badges(commands.Cog):
     if color:
       await db_set_user_badge_page_color_preference(ctx.author.id, "collection", color)
 
-    collection_label = f"{remove_emoji(ctx.author.display_name)}'s Unowned Badges [{PRESTIGE_TIERS[prestige]}]"
+    collection_label = "Unowned"
     badge_images = await generate_badge_collection_images(
       user=ctx.author,
       prestige=prestige,
@@ -380,7 +381,7 @@ class Badges(commands.Cog):
     special_badge_count = len(await db_get_special_badge_info())
     collection_count = max_badge_count - special_badge_count
     embed = discord.Embed(
-      title=f"{ctx.author.display_name}'s Missing Badges [{PRESTIGE_TIERS[prestige]}]",
+      title=f"{ctx.author.display_name}'s Unowned Badges [{PRESTIGE_TIERS[prestige]}]",
       description=f"Missing {len(unowned_badges)} of {collection_count}",
       color=discord.Color.blurple()
     )

--- a/cogs/badges.py
+++ b/cogs/badges.py
@@ -180,15 +180,17 @@ class Badges(commands.Cog):
     max_collected = await db_get_max_badge_count()
     collection_label = None
     if filter is not None:
+      max_collected = await db_get_badge_instances_count_for_user(ctx.author.id, prestige=prestige)
       if filter == 'unlocked':
         user_badges = await db_get_user_badge_instances(ctx.author.id, prestige=prestige, locked=False, sortby=sortby)
+        max_collected = await db_get_badge_instances_count_for_user(ctx.author.id, prestige=prestige, special=False)
       elif filter == 'locked':
         user_badges = await db_get_user_badge_instances(ctx.author.id, prestige=prestige, locked=True, sortby=sortby)
+        max_collected = await db_get_badge_instances_count_for_user(ctx.author.id, prestige=prestige, special=False)
       elif filter == 'special':
         user_badges = await db_get_user_badge_instances(ctx.author.id, prestige=prestige, special=True, sortby=sortby)
       elif filter == 'crystallized':
         user_badges = await db_get_user_badge_instances(ctx.author.id, prestige=prestige, crystallized=True, sortby=sortby)
-      max_collected = await db_get_badge_instances_count_for_user(ctx.author.id, prestige=prestige)
       collection_label = filter.title()
     else:
       user_badges = await db_get_user_badge_instances(ctx.author.id, prestige=prestige, sortby=sortby)
@@ -287,6 +289,149 @@ class Badges(commands.Cog):
             f.fp.close()
           except Exception:
             pass
+    badge_images.clear()
+    gc.collect()
+
+
+  # ____ ___                                     .___
+  # |    |   \____   ______  _  ______   ____   __| _/
+  # |    |   /    \ /  _ \ \/ \/ /    \_/ __ \ / __ |
+  # |    |  /   |  (  <_> )     /   |  \  ___// /_/ |
+  # |______/|___|  /\____/ \/\_/|___|  /\___  >____ |
+  #             \/                  \/     \/     \/
+  @badge_group.command(
+    name="unowned",
+    description="See which badges you're still missing at a given Prestige Tier."
+  )
+  @option(
+    name="public",
+    description="Show to public?",
+    required=True,
+    choices=[
+      discord.OptionChoice(name="No", value="no"),
+      discord.OptionChoice(name="Yes", value="yes")
+    ]
+  )
+  @option(
+    name="prestige",
+    description="Which Prestige Tier to check?",
+    required=True,
+    autocomplete=autocomplete_prestige_tiers
+  )
+  @option(
+    name="color",
+    description="Which colorscheme would you like? (Only applies to Standard Tier)",
+    required=False,
+    choices = [
+      discord.OptionChoice(name=color_choice, value=color_choice.lower())
+      for color_choice in ["Green", "Orange", "Purple", "Teal"]
+    ]
+  )
+  async def unowned(self, ctx: discord.ApplicationContext, public: str, prestige: str, color: str = None):
+    logger.info(f"{ctx.author.display_name} is pulling up their {Style.BRIGHT}`/badges unowned`{Style.RESET_ALL} badges for their {Style.BRIGHT}{PRESTIGE_TIERS[prestige]}{Style.RESET_ALL} Tier!")
+
+    if not await is_prestige_valid(ctx, prestige):
+      return
+    prestige = int(prestige)
+    public = (public == "yes")
+
+    unowned_badges = await db_get_unowned_user_badge_instances(ctx.author.id, prestige)
+
+    if not unowned_badges:
+      await ctx.respond(
+        embed=discord.Embed(
+          title="You've Collected Them All!",
+          description="You already own every badge available at this Prestige Tier! Wowzers.",
+          color=discord.Color.green()
+        ),
+        ephemeral=True
+      )
+      return
+
+    pending_message = await ctx.respond(
+      embed=discord.Embed(
+        title="Unowned Badge List Request Received!",
+        description=f"Compiling your uncollected badge records...\nStand by! {get_emoji('badgey_smile_happy')}",
+        color=discord.Color.dark_teal()
+      ),
+      ephemeral=not public
+    )
+
+    if color:
+      await db_set_user_badge_page_color_preference(ctx.author.id, "collection", color)
+
+    collection_label = f"{remove_emoji(ctx.author.display_name)}'s Unowned Badges [{PRESTIGE_TIERS[prestige]}]"
+    badge_images = await generate_badge_collection_images(
+      user=ctx.author,
+      prestige=prestige,
+      badge_data=unowned_badges,
+      collection_type="collection",
+      collection_label=collection_label,
+      discord_message=pending_message
+    )
+
+    await pending_message.edit(embed=discord.Embed(
+      title="Unowned Badges Displayed!",
+      description="Here's your current missing badges list!",
+      color=discord.Color.dark_teal()
+    ))
+
+    max_badge_count = await db_get_max_badge_count()
+    special_badge_count = len(await db_get_special_badge_info())
+    collection_count = max_badge_count - special_badge_count
+    embed = discord.Embed(
+      title=f"{ctx.author.display_name}'s Missing Badges [{PRESTIGE_TIERS[prestige]}]",
+      description=f"Missing {len(unowned_badges)} of {collection_count}",
+      color=discord.Color.blurple()
+    )
+
+    if not public:
+      buttons = [
+        pages.PaginatorButton("prev", label="⬅", style=discord.ButtonStyle.primary, disabled=(len(unowned_badges) <= 30), row=1),
+        pages.PaginatorButton("page_indicator", style=discord.ButtonStyle.gray, disabled=True, row=1),
+        pages.PaginatorButton("next", label="➡", style=discord.ButtonStyle.primary, disabled=(len(unowned_badges) <= 30), row=1),
+      ]
+
+      class UnownedPaginator(pages.Paginator):
+        def __init__(self, *args, badge_files: list[discord.File], **kwargs):
+          self.badge_files = badge_files
+          super().__init__(*args, **kwargs)
+
+        async def on_timeout(self):
+          for f in self.badge_files:
+            try: f.fp.close()
+            except: pass
+          self.badge_files.clear()
+          gc.collect()
+
+      pages_list = [
+        pages.Page(files=[image], embeds=[embed])
+        for image in badge_images
+      ]
+
+      paginator = UnownedPaginator(
+        pages=pages_list,
+        badge_files=badge_images,
+        show_disabled=True,
+        show_indicator=True,
+        use_default_buttons=False,
+        custom_buttons=buttons,
+        loop_pages=True,
+        timeout=600
+      )
+      await paginator.respond(ctx.interaction, ephemeral=True)
+
+    else:
+      file_chunks = [badge_images[i:i + 10] for i in range(0, len(badge_images), 10)]
+      for i, chunk in enumerate(file_chunks):
+        if i == len(file_chunks) - 1:
+          await ctx.followup.send(embed=embed, files=chunk)
+        else:
+          await ctx.followup.send(files=chunk)
+        for f in chunk:
+          try: f.fp.close()
+          except: pass
+
     badge_images.clear()
     gc.collect()
 

--- a/cogs/tongo.py
+++ b/cogs/tongo.py
@@ -372,15 +372,16 @@ class Tongo(commands.Cog):
       )
       await zeks_table.send(embed=downtime_embed)
       await self._perform_confront(active_tongo, chair)
+      if self.auto_confront.is_running():
+        self.auto_confront.cancel()
       self.first_auto_confront = True
     else:
+      if self.auto_confront.is_running():
+        self.auto_confront.cancel()
       self.first_auto_confront = True
+
       self.auto_confront.change_interval(seconds=remaining.total_seconds())
-      try:
-        self.auto_confront.start()
-      except RuntimeError:
-        logger.warning("Tongo auto_confront loop was already running.")
-        raise
+      self.auto_confront.start()
 
       # Disallow any consortium investments cause we don't know what the previous state was.. :\
       self.zek_consortium_activated = True

--- a/cogs/tongo.py
+++ b/cogs/tongo.py
@@ -293,9 +293,8 @@ class TongoDividendsView(discord.ui.View):
 
 class TongoPaginator(pages.Paginator):
   async def on_timeout(self):
-    # Reset to page
-    self.current_page = 0
-    await self.update()
+    # Reset to first page
+    await self.update(current_page=0)
     # Then disable view
     if self.disable_on_timeout:
       await self.disable()
@@ -415,6 +414,7 @@ class Tongo(commands.Cog):
     required=True,
     autocomplete=autocomplete_prestige_tiers
   )
+  @commands.check(access_check)
   async def venture(self, ctx: discord.ApplicationContext, prestige: str):
     await ctx.defer(ephemeral=True)
 
@@ -606,6 +606,7 @@ class Tongo(commands.Cog):
     required=True,
     autocomplete=autocomplete_prestige_tiers
   )
+  @commands.check(access_check)
   async def risk(self, ctx: discord.ApplicationContext, prestige: str):
     await ctx.defer(ephemeral=True)
 

--- a/cogs/tongo.py
+++ b/cogs/tongo.py
@@ -23,8 +23,7 @@ from utils.image_utils import *
 from utils.prestige import *
 from utils.string_utils import escape_discord_formatting as edf
 
-
-# cogs.tongo
+PACIFIC = timezone("America/Los_Angeles")
 
 f = open("./data/rules_of_acquisition.txt", "r")
 data = f.read()
@@ -352,7 +351,7 @@ class Tongo(commands.Cog):
 
     time_created = active_tongo['created_at']
     if time_created.tzinfo is None:
-      time_created = time_created.replace(tzinfo=timezone.utc)
+      time_created = PACIFIC.localize(time_created).astimezone(timezone.utc)
 
     current_time = datetime.now(timezone.utc)
     elapsed = current_time - time_created

--- a/configuration.json
+++ b/configuration.json
@@ -418,6 +418,16 @@
       "enabled": true,
       "parameters": []
     },
+    "badges unowned": {
+      "channels": [
+        "badgeys-badges",
+        "bahrats-bazaar",
+        "gelrak-v",
+        "zeks-table"
+      ],
+      "enabled": true,
+      "parameters": []
+    },
     "bless": {
       "channels": [],
       "enabled": true,

--- a/migrations/v3.13.0.sql
+++ b/migrations/v3.13.0.sql
@@ -1,3 +1,7 @@
 UPDATE badge_info
 SET badge_url = REPLACE(badge_url, 'united-federation-of-planets-ufp', 'united-federation-of-planets-(ufp)')
 WHERE badge_url LIKE '%united-federation-of-planets-ufp%';
+
+UPDATE badge_info
+SET badge_url = REPLACE(badge_url, 'federation-news-network-fnn', 'federation-news-network-(fnn)')
+WHERE badge_url LIKE '%federation-news-network-fnn%';

--- a/migrations/v3.13.0.sql
+++ b/migrations/v3.13.0.sql
@@ -1,0 +1,3 @@
+UPDATE badge_info
+SET badge_url = REPLACE(badge_url, 'united-federation-of-planets-ufp', 'united-federation-of-planets-(ufp)')
+WHERE badge_url LIKE '%united-federation-of-planets-ufp%';

--- a/utils/image_utils.py
+++ b/utils/image_utils.py
@@ -489,7 +489,8 @@ def _compose_grid_slot(badge, collection_type, theme, badge_image):
 
   colors = get_theme_colors(theme)
 
-  unowned = collection_type == 'sets' and not badge.get('in_user_collection')
+  # unowned = collection_type == 'sets' and not badge.get('in_user_collection')
+  unowned = badge.get('in_user_collection') is not None and badge.get('in_user_collection') is False
   if unowned:
     faded_frames = []
     frames = badge_image if isinstance(badge_image, list) else [badge_image]

--- a/utils/image_utils.py
+++ b/utils/image_utils.py
@@ -489,7 +489,6 @@ def _compose_grid_slot(badge, collection_type, theme, badge_image):
 
   colors = get_theme_colors(theme)
 
-  # unowned = collection_type == 'sets' and not badge.get('in_user_collection')
   unowned = badge.get('in_user_collection') is not None and badge.get('in_user_collection') is False
   if unowned:
     faded_frames = []


### PR DESCRIPTION
# Has a migration!

`MIGRATION_FILE=./migrations/v3.13.0.sql make db-migrate`

* New command `/badges unowned` - Shows which badges you need to still collect to complete a given Tier
* Fix for some STDP urls
* Fix for Tongo paginator page 0 reset