### PR TITLE
Attach audio and forward messages with no content in starboard

### DIFF
--- a/charts/agimus/Chart.yaml
+++ b/charts/agimus/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agimus
 description: A helm chart for a discord bot that also runs a mysql db
 type: application
-version: v3.23.13
-appVersion: v3.23.13
+version: v3.23.14
+appVersion: v3.23.14

--- a/handlers/starboard.py
+++ b/handlers/starboard.py
@@ -221,7 +221,7 @@ async def add_starboard_post(message: discord.Message, board: str):
   elif len(message.attachments) > 0:
     # build attachments
     attachment = message.attachments[0]
-    if attachment.content_type.startswith("video"):
+    if attachment.content_type.startswith(("video", "audio")):
       star_file = await attachment.to_file(spoiler=attachment.is_spoiler())
     else:
       if attachment.is_spoiler():
@@ -229,6 +229,9 @@ async def add_starboard_post(message: discord.Message, board: str):
         star_file = await attachment.to_file(spoiler=True)
       elif attachment.content_type.startswith("image"):
         star_embed.set_image(url=attachment.proxy_url)
+  elif star_embed.description == "":
+    # If it’s a forwarded message, all we can do is reforward it
+    await message.forward_to(channel)
 
   if embed_thumb != "":
     star_embed.set_thumbnail(url=embed_thumb)


### PR DESCRIPTION
Sometimes starboard messages just don’t have content.  This will fix the two common ones: voice memos and forwarded messages.  Ideally, we could forward in the embed, or take some of the content of the original post, but that’s not allowed in Discord at all, so this ugly compromise

Examples:
https://discord.com/channels/993234668319162439/1203367492483813376/1496226806712369243
https://discord.com/channels/993234668319162439/1203367492483813376/1495289883999342703

Closes #703